### PR TITLE
c_cpp_properties platform independent

### DIFF
--- a/scripts/pico_project.py
+++ b/scripts/pico_project.py
@@ -830,10 +830,10 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger, 
             "name": "Pico",
             "includePath": [
                 "${{workspaceFolder}}/**",
-                "{propertiesSdkPath(sdkVersion)}/**"
+                "{codeSdkPath(sdkVersion)}/**"
             ],
             "forcedInclude": [
-                "{propertiesSdkPath(sdkVersion)}/src/common/pico_base/include/pico.h",
+                "{codeSdkPath(sdkVersion)}/src/common/pico_base/include/pico.h",
                 "${{workspaceFolder}}/build/generated/pico_base/pico/config_autogen.h"
             ],
             "defines": [],
@@ -1138,7 +1138,7 @@ if args.name == None and not args.gui and not args.list and not args.configs and
 if args.cpath:
     compilerPath = Path(args.cpath)
 elif args.toolchainVersion:
-    compilerPath = Path(propertiesToolchainPath(args.toolchainVersion)+"/bin/"+COMPILER_NAME)
+    compilerPath = Path(codeToolchainPath(args.toolchainVersion)+"/bin/"+COMPILER_NAME)
 else:
     compilerPath = Path(c)
 

--- a/src/utils/vscodeConfigUtil.mts
+++ b/src/utils/vscodeConfigUtil.mts
@@ -28,13 +28,13 @@ async function updateCppPropertiesFile(
     cppProperties.configurations.forEach(config => {
       // Remove the old pico-sdk includePath values set by this extension
       config.includePath = config.includePath.filter(
-        item => !item.startsWith("${env:HOME}/.pico-sdk")
+        item => !item.startsWith("${userHome}/.pico-sdk")
       );
       // Add the new pico-sdk includePath
-      config.includePath.push(`\${env:HOME}/.pico-sdk/sdk/${newSDKVersion}/**`);
+      config.includePath.push(`\${userHome}/.pico-sdk/sdk/${newSDKVersion}/**`);
       // Update the compilerPath
       config.compilerPath =
-        "${env:HOME}/.pico-sdk/toolchain" +
+        "${userHome}/.pico-sdk/toolchain" +
         `/${newToolchainVersion}/bin/${
           // "arm-none-eabi-gcc" should work on all platforms no need for extension on Windows
           /*process.platform === "win32"
@@ -94,10 +94,7 @@ function relativeToolchainPath(toolchainVersion: string): string {
  * @returns The path to the toolchain.
  */
 function buildPropertiesToolchainPathBin(toolchainVersion: string): string {
-  // TODO: may home is also available in newer versions of windows
-  return `${
-    process.platform === "win32" ? "${env:USERPROFILE}" : "${env:HOME}"
-  }${relativeToolchainPath(toolchainVersion)}/bin`;
+  return `\${userHome}${relativeToolchainPath(toolchainVersion)}/bin`;
 }
 
 function buildCMakePath(cmakeVersion: string): string {


### PR DESCRIPTION
The c-cpp extension for vscode [added support for `${userHome}`](https://github.com/microsoft/vscode-cpptools/issues/11756) a platform independent home variable with version [`1.20.0`](https://github.com/microsoft/vscode-cpptools/releases/tag/v1.20.0). Since it is only a pre-release for now this pull request remains a draft.

This also fixes an issue with `switchSDK` not updating `c_cpp_properties.json` on Windows correctly.