### PR TITLE
Use toolchain GDB on MacOS

### DIFF
--- a/scripts/pico_project.py
+++ b/scripts/pico_project.py
@@ -735,7 +735,7 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger, 
     if debugger == "raspberrypi-swd.cfg":
         shutil.copyfile(sourcefolder + "/" +  "raspberrypi-swd.cfg", projectPath / "raspberrypi-swd.cfg")
 
-    gdbPath =  Path(codeToolchainPath(toolchainVersion)+"/bin/arm-none-eabi-gdb").as_posix() if isWindows else "gdb-multiarch" if isMac else "gdb"
+    gdbPath =  Path(codeToolchainPath(toolchainVersion)+"/bin/arm-none-eabi-gdb").as_posix() if isWindows or isMac else "gdb"
     # Need to escape windows files paths backslashes
     # TODO: env in currently not supported in compilerPath var
     #cPath = f"${{env:PICO_TOOLCHAIN_PATH_{envSuffix}}}" + os.path.sep + os.path.basename(str(compilerPath).replace('\\', '\\\\' ))


### PR DESCRIPTION
Currently on MacOS we use `gdb-multiarch` for debugging, but that is not necessarily installed. This change is to use the arm toolchain gdb like on windows, although it requires testing before merging