### PR TITLE
Add support for cmake-tools extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,11 @@
           "default": true,
           "markdownDescription": "Automatically run configure when opening a Pico project"
         },
+        "raspberry-pi-pico.useCmakeTools": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Use the CMake Tools extension for CMake configuration, instead of this extension"
+        },
         "raspberry-pi-pico.githubToken": {
           "type": "string",
           "default": "",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,18 @@
         "enablement": "false"
       },
       {
+        "command": "raspberry-pi-pico.getPythonPath",
+        "title": "Get python path",
+        "category": "Raspberry Pi Pico",
+        "enablement": "false"
+      },
+      {
+        "command": "raspberry-pi-pico.getEnvPath",
+        "title": "Get environment path",
+        "category": "Raspberry Pi Pico",
+        "enablement": "false"
+      },
+      {
         "command": "raspberry-pi-pico.compileProject",
         "title": "Compile Pico Project",
         "category": "Raspberry Pi Pico",

--- a/scripts/pico_project.py
+++ b/scripts/pico_project.py
@@ -781,8 +781,7 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger, 
             ],
             "openOCDLaunchCommands": [
                 "adapter speed 5000"
-            ],
-            "preLaunchTask": "Compile Project"
+            ]
         }},
         {{
             "name": "Pico Debug (Cortex-Debug with external OpenOCD)",
@@ -800,8 +799,7 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger, 
             "postRestartCommands": [
                 "break main",
                 "continue"
-            ],
-            "preLaunchTask": "Compile Project"
+            ]
         }},
         {{
             "name": "Pico Debug (C++ Debugger)",
@@ -907,6 +905,7 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger, 
         "PATH": "{propertiesToolchainPath(toolchainVersion, force_non_windows=True)}/bin:{os.path.dirname(cmakePath.replace(user_home, "${env:HOME}") if use_home_var else cmakePath)}:{os.path.dirname(ninjaPath.replace(user_home, "${env:HOME}") if use_home_var else ninjaPath)}:${{env:PATH}}"
     }},
     "raspberry-pi-pico.cmakeAutoConfigure": true,
+    "raspberry-pi-pico.useCmakeTools": false,
     "raspberry-pi-pico.cmakePath": "{cmakePath.replace(user_home, "${HOME}") if use_home_var else cmakePath}",
     "raspberry-pi-pico.ninjaPath": "{ninjaPath.replace(user_home, "${HOME}") if use_home_var else ninjaPath}"'''
 
@@ -949,7 +948,6 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger, 
         {{
             "label": "Flash",
             "type": "process",
-            "dependsOn": "Compile Project",
             "command": "{openocd_path if openocd_path else "openocd"}",
             "args": [
                 "-f",

--- a/scripts/pico_project.py
+++ b/scripts/pico_project.py
@@ -27,6 +27,7 @@ COMPILER_NAME = 'arm-none-eabi-gcc'
 
 VSCODE_LAUNCH_FILENAME = 'launch.json'
 VSCODE_C_PROPERTIES_FILENAME = 'c_cpp_properties.json'
+VSCODE_CMAKE_KITS_FILENAME ='cmake-kits.json'
 VSCODE_SETTINGS_FILENAME ='settings.json'
 VSCODE_EXTENSIONS_FILENAME ='extensions.json'
 VSCODE_TASKS_FILENAME ='tasks.json'
@@ -740,7 +741,7 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger, 
     # Need to escape windows files paths backslashes
     # TODO: env in currently not supported in compilerPath var
     #cPath = f"${{env:PICO_TOOLCHAIN_PATH_{envSuffix}}}" + os.path.sep + os.path.basename(str(compilerPath).replace('\\', '\\\\' ))
-    cPath = compilerPath.as_posix()
+    cPath = compilerPath.as_posix() + (".exe" if isWindows else "")
 
     # if this is a path in the .pico-sdk homedir tell the settings to use the homevar
     user_home = os.path.expanduser("~").replace("\\", "/")
@@ -851,6 +852,24 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger, 
 '''
 
             pythonExe = sys.executable.replace("\\", "/").replace(user_home, "${HOME}") if use_home_var else sys.executable
+
+            # kits
+            kits = f'''[
+    {{
+        "name": "Pico",
+        "compilers": {{
+            "C": "{cPath}",
+            "CXX": "{cPath}"
+        }},
+        "toolchainFile": "{propertiesSdkPath(sdkVersion)}/cmake/preload/toolchains/pico_arm_gcc.cmake",
+        "environmentVariables": {{
+            "PATH": "${{command:raspberry-pi-pico.getEnvPath}};${{env:PATH}}"
+        }},
+        "cmakeSettings": {{
+            "Python3_EXECUTABLE": "${{command:raspberry-pi-pico.getPythonPath}}"
+        }}
+    }}
+]'''
 
             # settings
             settings = f'''{{
@@ -963,6 +982,10 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger, 
 
             file = open(VSCODE_C_PROPERTIES_FILENAME, 'w')
             file.write(properties)
+            file.close()
+
+            file = open(VSCODE_CMAKE_KITS_FILENAME, 'w')
+            file.write(kits)
             file.close()
 
             file = open(VSCODE_SETTINGS_FILENAME, 'w')

--- a/src/commands/compileProject.mts
+++ b/src/commands/compileProject.mts
@@ -1,6 +1,7 @@
-import { tasks, window } from "vscode";
+import { commands, tasks, window } from "vscode";
 import { Command } from "./command.mjs";
 import Logger from "../logger.mjs";
+import Settings, { SettingsKey } from "../settings.mjs";
 
 export default class CompileProjectCommand extends Command {
   private _logger: Logger = new Logger("CompileProjectCommand");
@@ -18,6 +19,18 @@ export default class CompileProjectCommand extends Command {
 
       return task.name === "Compile Project";
     });
+
+    const settings = Settings.getInstance();
+    if (
+      settings !== undefined && settings.getBoolean(SettingsKey.useCmakeTools)
+    ) {
+      // Compile with CMake Tools
+      await commands.executeCommand(
+        "cmake.launchTargetPath"
+      );
+
+      return;
+    }
 
     if (task) {
       // Execute the task

--- a/src/commands/getPaths.mts
+++ b/src/commands/getPaths.mts
@@ -1,0 +1,43 @@
+import { CommandWithResult } from "./command.mjs";
+import { workspace } from "vscode";
+import { getPythonPath, getPath } from "../utils/cmakeUtil.mjs";
+
+export class GetPythonPathCommand
+                      extends CommandWithResult<string> {
+  constructor() {
+    super("getPythonPath");
+  }
+
+  async execute(): Promise<string> {
+    if (
+      workspace.workspaceFolders === undefined ||
+      workspace.workspaceFolders.length === 0
+    ) {
+      return "";
+    }
+
+    const pythonPath = await getPythonPath();
+
+    return pythonPath;
+  }
+}
+
+export class GetEnvPathCommand
+                      extends CommandWithResult<string> {
+  constructor() {
+    super("getEnvPath");
+  }
+
+  async execute(): Promise<string> {
+    if (
+      workspace.workspaceFolders === undefined ||
+      workspace.workspaceFolders.length === 0
+    ) {
+      return "";
+    }
+
+    const path = await getPath();
+
+    return path;
+  }
+}

--- a/src/extension.mts
+++ b/src/extension.mts
@@ -30,6 +30,10 @@ import { basename, join } from "path";
 import CompileProjectCommand from "./commands/compileProject.mjs";
 import LaunchTargetPathCommand from "./commands/launchTargetPath.mjs";
 import {
+  GetPythonPathCommand,
+  GetEnvPathCommand
+} from "./commands/getPaths.mjs";
+import {
   downloadAndInstallCmake,
   downloadAndInstallNinja,
   downloadAndInstallSDK,
@@ -80,6 +84,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
       new NewProjectCommand(context.extensionUri),
       new SwitchSDKCommand(ui, context.extensionUri),
       new LaunchTargetPathCommand(),
+      new GetPythonPathCommand(),
+      new GetEnvPathCommand(),
       new CompileProjectCommand(),
       new ClearGithubApiCacheCommand(),
       new ConditionalDebuggingCommand(),

--- a/src/settings.mts
+++ b/src/settings.mts
@@ -12,6 +12,7 @@ export enum SettingsKey {
   gitPath = "gitPath",
   cmakeAutoConfigure = "cmakeAutoConfigure",
   githubToken = "githubToken",
+  useCmakeTools = "useCmakeTools",
 }
 
 /**

--- a/src/utils/cmakeUtil.mts
+++ b/src/utils/cmakeUtil.mts
@@ -101,6 +101,15 @@ export async function configureCmakeNinja(folder: Uri): Promise<boolean> {
     return false;
   }
 
+  if (settings.getBoolean(SettingsKey.useCmakeTools)) {
+    await window.showErrorMessage(
+      "You must use the CMake Tools extension to configure your build. " +
+      "To use this extension instead, change the useCmakeTools setting."
+    );
+
+    return false;
+  }
+
   try {
     // check if CMakeLists.txt exists in the root folder
     await workspace.fs.stat(

--- a/src/utils/cmakeUtil.mts
+++ b/src/utils/cmakeUtil.mts
@@ -11,6 +11,88 @@ import { rimraf, windows as rimrafWindows } from "rimraf";
 import { homedir } from "os";
 import which from "which";
 
+export async function getPythonPath(): Promise<string> {
+  const settings = Settings.getInstance();
+  if (settings === undefined) {
+    Logger.log("Error: Settings not initialized.");
+
+    return "";
+  }
+
+  const pythonPath = (
+    await which(
+      settings
+        .getString(SettingsKey.python3Path)
+        ?.replace(HOME_VAR, homedir()) ||
+        (process.platform === "win32" ? "python" : "python3"),
+      { nothrow: true }
+    )
+  ).replaceAll("\\", "/");
+
+  return `${pythonPath.replaceAll("\\", "/")}`;
+}
+
+export async function getPath(): Promise<string> {
+  const settings = Settings.getInstance();
+  if (settings === undefined) {
+    Logger.log("Error: Settings not initialized.");
+
+    return "";
+  }
+
+  const ninjaPath = (
+    await which(
+      settings
+        .getString(SettingsKey.ninjaPath)
+        ?.replace(HOME_VAR, homedir()) || "ninja",
+      { nothrow: true }
+    )
+  ).replaceAll("\\", "/");
+  const cmakePath = (
+    await which(
+      settings
+        .getString(SettingsKey.cmakePath)
+        ?.replace(HOME_VAR, homedir()) || "cmake",
+      { nothrow: true }
+    )
+  ).replaceAll("\\", "/");
+  Logger.log(
+    settings.getString(SettingsKey.python3Path)?.replace(HOME_VAR, homedir())
+  );
+  // TODO: maybe also check for "python" on unix systems
+  const pythonPath = await getPythonPath();
+
+  if (ninjaPath === null || cmakePath === null) {
+    const missingTools = [];
+    if (ninjaPath === null) {
+      missingTools.push("Ninja");
+    }
+    if (cmakePath === null) {
+      missingTools.push("CMake");
+    }
+    if (pythonPath === null) {
+      missingTools.push("Python 3");
+    }
+    void showRequirementsNotMetErrorMessage(missingTools);
+
+    return "";
+  }
+
+  const isWindows = process.platform === "win32";
+
+  return `${
+    ninjaPath.includes("/") ? dirname(ninjaPath) : ""
+  }${
+    cmakePath.includes("/")
+      ? `${isWindows ? ";" : ":"}${dirname(cmakePath)}`
+      : ""
+  }${
+    pythonPath.includes("/")
+      ? `${dirname(pythonPath)}${isWindows ? ";" : ":"}`
+      : ""
+  }`;
+}
+
 export async function configureCmakeNinja(folder: Uri): Promise<boolean> {
   const settings = Settings.getInstance();
   if (settings === undefined) {
@@ -24,52 +106,6 @@ export async function configureCmakeNinja(folder: Uri): Promise<boolean> {
     await workspace.fs.stat(
       folder.with({ path: join(folder.fsPath, "CMakeLists.txt") })
     );
-
-    const ninjaPath = (
-      await which(
-        settings
-          .getString(SettingsKey.ninjaPath)
-          ?.replace(HOME_VAR, homedir()) || "ninja",
-        { nothrow: true }
-      )
-    ).replaceAll("\\", "/");
-    const cmakePath = (
-      await which(
-        settings
-          .getString(SettingsKey.cmakePath)
-          ?.replace(HOME_VAR, homedir()) || "cmake",
-        { nothrow: true }
-      )
-    ).replaceAll("\\", "/");
-    Logger.log(
-      settings.getString(SettingsKey.python3Path)?.replace(HOME_VAR, homedir())
-    );
-    // TODO: maybe also check for "python" on unix systems
-    const pythonPath = (
-      await which(
-        settings
-          .getString(SettingsKey.python3Path)
-          ?.replace(HOME_VAR, homedir()) ||
-          (process.platform === "win32" ? "python" : "python3"),
-        { nothrow: true }
-      )
-    ).replaceAll("\\", "/");
-
-    if (ninjaPath === null || cmakePath === null) {
-      const missingTools = [];
-      if (ninjaPath === null) {
-        missingTools.push("Ninja");
-      }
-      if (cmakePath === null) {
-        missingTools.push("CMake");
-      }
-      if (pythonPath === null) {
-        missingTools.push("Python 3");
-      }
-      void showRequirementsNotMetErrorMessage(missingTools);
-
-      return false;
-    }
 
     void window.withProgress(
       {
@@ -93,17 +129,13 @@ export async function configureCmakeNinja(folder: Uri): Promise<boolean> {
           ? resolve(join(dirname(pythonPath), ".."))
           : "";*/
         const isWindows = process.platform === "win32";
-        customEnv[isWindows ? "Path" : "PATH"] = `${
-          ninjaPath.includes("/") ? dirname(ninjaPath) : ""
-        }${
-          cmakePath.includes("/")
-            ? `${isWindows ? ";" : ":"}${dirname(cmakePath)}`
-            : ""
-        }${
-          pythonPath.includes("/")
-            ? `${dirname(pythonPath)}${isWindows ? ";" : ":"}`
-            : ""
-        }${customEnv[isWindows ? "Path" : "PATH"]}`;
+        const customPath = await getPath();
+        if (!customPath) {
+          return false;
+        }
+        customEnv[isWindows ? "Path" : "PATH"] = customPath
+          + customEnv[isWindows ? "Path" : "PATH"];
+        const pythonPath = await getPythonPath();
 
         const command =
           `${


### PR DESCRIPTION
Add a cmake-kits.json, which allows the cmake-tools extension to compile the project, using the correct Ninja, Python, and compiler.

By default we will still use our cmake configuration function, but this allows more advanced users to use the cmake-tools extension instead, which allows configuration of things like build directories elsewhere.