### PR TITLE
Use extension dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Modify package.json for OVSX
         # ms-vscode extensions not available on OpenVSX registry, so remove dependencies
         run: |
-          sed -i 's/\n\s"ms-vscode.*",//g' package.json
+          sed -i 's/"ms-vscode.*",//g' package.json
       - name: Package Extension for OVSX
         run: |
           vsce package -o ovsx-raspberry-pi-pico.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
           sed -i 's/\n\s"ms-vscode.*",//g' package.json
       - name: Package Extension for OVSX
         run: |
-          yarn lint
           vsce package -o ovsx-raspberry-pi-pico.vsix
       - name: Test PAT
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,14 @@ jobs:
         run: |
           yarn lint
           vsce package
+      - name: Modify package.json for OVSX
+        # ms-vscode extensions not available on OpenVSX registry, so remove dependencies
+        run: |
+          sed -i 's/\n\s"ms-vscode.*",//g' package.json
+      - name: Package Extension for OVSX
+        run: |
+          yarn lint
+          vsce package -o ovsx-raspberry-pi-pico.vsix
       - name: Test PAT
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
         env:
@@ -43,12 +51,16 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: raspberry-pi-pico
-          path: raspberry-pi-pico-*.vsix
+          path: |
+            raspberry-pi-pico-*.vsix
+            ovsx-raspberry-pi-pico.vsix
       - name: Add Release Asset
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: raspberry-pi-pico-*.vsix
+          files: |
+            raspberry-pi-pico-*.vsix
+            ovsx-raspberry-pi-pico.vsix
       - name: Publish Extension
         if: startsWith(github.ref, 'refs/tags/')
         env:
@@ -58,4 +70,4 @@ jobs:
       - name: Publish Extension to OVSX
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          npx ovsx publish raspberry-pi-pico-*.vsix -p ${{ secrets.OPEN_VSX_PAT }}
+          npx ovsx publish ovsx-raspberry-pi-pico.vsix -p ${{ secrets.OPEN_VSX_PAT }}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "Snippets",
     "Other"
   ],
-  "extensionPack": [
+  "extensionDependencies": [
     "marus25.cortex-debug",
     "ms-vscode.cpptools",
     "ms-vscode.cpptools-extension-pack",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "Other"
   ],
   "extensionDependencies": [
-    "marus25.cortex-debug",
     "ms-vscode.cpptools",
     "ms-vscode.cpptools-extension-pack",
-    "ms-vscode.vscode-serial-monitor"
+    "ms-vscode.vscode-serial-monitor",
+    "marus25.cortex-debug"
   ],
   "main": "./dist/extension.cjs",
   "markdown": "github",


### PR DESCRIPTION
Use extension dependencies, rather than installing as an extension pack

This fixes uninstall issues, where uninstalling the extension would also uninstall the Microsoft C/C++ extensions

This now requires a separate package for OpenVSX, as that package can't depend on the Microsoft C/C++ extensions, as they're not availble on OpenVSX

Fixes #51 and #55 