### PR TITLE
Add more examples, with supported boards

### DIFF
--- a/data/0.16.0/examples.json
+++ b/data/0.16.0/examples.json
@@ -1315,4 +1315,4 @@
         ],
         "supportRiscV": true
     }
-}
+}

--- a/data/0.16.0/examples.json
+++ b/data/0.16.0/examples.json
@@ -1,0 +1,1318 @@
+{
+    "hello_usb": {
+        "path": "hello_world/usb",
+        "name": "usb",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_serial": {
+        "path": "hello_world/serial",
+        "name": "serial",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pwm_led_fade": {
+        "path": "pwm/led_fade",
+        "name": "led_fade",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_pwm": {
+        "path": "pwm/hello_pwm",
+        "name": "hello_pwm",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pwm_measure_duty_cycle": {
+        "path": "pwm/measure_duty_cycle",
+        "name": "measure_duty_cycle",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_48MHz": {
+        "path": "clocks/hello_48MHz",
+        "name": "hello_48MHz",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_resus": {
+        "path": "clocks/hello_resus",
+        "name": "hello_resus",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "clocks_detached_clk_peri": {
+        "path": "clocks/detached_clk_peri",
+        "name": "detached_clk_peri",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_gpout": {
+        "path": "clocks/hello_gpout",
+        "name": "hello_gpout",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "uart_advanced": {
+        "path": "uart/uart_advanced",
+        "name": "uart_advanced",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "lcd_uart": {
+        "path": "uart/lcd_uart",
+        "name": "lcd_uart",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_uart": {
+        "path": "uart/hello_uart",
+        "name": "hello_uart",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "dht": {
+        "path": "gpio/dht_sensor",
+        "name": "dht_sensor",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_7segment": {
+        "path": "gpio/hello_7segment",
+        "name": "hello_7segment",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_gpio_irq": {
+        "path": "gpio/hello_gpio_irq",
+        "name": "hello_gpio_irq",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "blink": {
+        "path": "blink",
+        "name": "blink",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "blink_simple": {
+        "path": "blink_simple",
+        "name": "blink_simple",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_watchdog": {
+        "path": "watchdog/hello_watchdog",
+        "name": "hello_watchdog",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_hub75": {
+        "path": "pio/hub75",
+        "name": "hub75",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_pwm": {
+        "path": "pio/pwm",
+        "name": "pwm",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_manchester_encoding": {
+        "path": "pio/manchester_encoding",
+        "name": "manchester_encoding",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_differential_manchester": {
+        "path": "pio/differential_manchester",
+        "name": "differential_manchester",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_addition": {
+        "path": "pio/addition",
+        "name": "addition",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_onewire": {
+        "path": "pio/onewire",
+        "name": "onewire",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_squarewave": {
+        "path": "pio/squarewave",
+        "name": "squarewave",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_squarewave_div_sync": {
+        "path": "pio/squarewave",
+        "name": "squarewave",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_clocked_input": {
+        "path": "pio/clocked_input",
+        "name": "clocked_input",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_blink": {
+        "path": "pio/pio_blink",
+        "name": "pio_blink",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_quadrature_encoder_substep": {
+        "path": "pio/quadrature_encoder_substep",
+        "name": "quadrature_encoder_substep",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_quadrature_encoder": {
+        "path": "pio/quadrature_encoder",
+        "name": "quadrature_encoder",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_ws2812": {
+        "path": "pio/ws2812",
+        "name": "ws2812",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_uart_rx": {
+        "path": "pio/uart_rx",
+        "name": "uart_rx",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_uart_rx_intr": {
+        "path": "pio/uart_rx",
+        "name": "uart_rx",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_logic_analyser": {
+        "path": "pio/logic_analyser",
+        "name": "logic_analyser",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_ir_loopback": {
+        "path": "pio/ir_nec/ir_loopback",
+        "name": "ir_loopback",
+        "libPaths": [
+            "pio/ir_nec/nec_receive_library",
+            "pio/ir_nec/nec_transmit_library"
+        ],
+        "libNames": [
+            "nec_receive_library",
+            "nec_transmit_library"
+        ],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_i2c_bus_scan": {
+        "path": "pio/i2c",
+        "name": "i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_spi_flash": {
+        "path": "pio/spi",
+        "name": "spi",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_spi_loopback": {
+        "path": "pio/spi",
+        "name": "spi",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_apa102": {
+        "path": "pio/apa102",
+        "name": "apa102",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_uart_tx": {
+        "path": "pio/uart_tx",
+        "name": "uart_tx",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pio_st7789_lcd": {
+        "path": "pio/st7789_lcd",
+        "name": "st7789_lcd",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_pio": {
+        "path": "pio/hello_pio",
+        "name": "hello_pio",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "picoboard_button": {
+        "path": "picoboard/button",
+        "name": "button",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "picoboard_blinky": {
+        "path": "picoboard/blinky",
+        "name": "blinky",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_divider": {
+        "path": "divider",
+        "name": "divider",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "unique_board_id": {
+        "path": "system/unique_board_id",
+        "name": "unique_board_id",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "rand": {
+        "path": "system/rand",
+        "name": "rand",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_double_tap": {
+        "path": "system/hello_double_tap",
+        "name": "hello_double_tap",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "narrow_io_write": {
+        "path": "system/narrow_io_write",
+        "name": "narrow_io_write",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "flash_program": {
+        "path": "flash/program",
+        "name": "program",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "flash_xip_stream": {
+        "path": "flash/xip_stream",
+        "name": "xip_stream",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "flash_ssi_dma": {
+        "path": "flash/ssi_dma",
+        "name": "ssi_dma",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w"
+        ],
+        "supportRiscV": false
+    },
+    "flash_nuke": {
+        "path": "flash/nuke",
+        "name": "nuke",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "flash_cache_perfctr": {
+        "path": "flash/cache_perfctr",
+        "name": "cache_perfctr",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w"
+        ],
+        "supportRiscV": false
+    },
+    "hello_timer": {
+        "path": "timer/hello_timer",
+        "name": "hello_timer",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "timer_lowlevel": {
+        "path": "timer/timer_lowlevel",
+        "name": "timer_lowlevel",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "periodic_sampler": {
+        "path": "timer/periodic_sampler",
+        "name": "periodic_sampler",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "dev_hid_composite": {
+        "path": "usb/device/dev_hid_composite",
+        "name": "dev_hid_composite",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "dev_lowlevel": {
+        "path": "usb/device/dev_lowlevel",
+        "name": "dev_lowlevel",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "host_cdc_msc_hid": {
+        "path": "usb/host/host_cdc_msc_hid",
+        "name": "host_cdc_msc_hid",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "rtc_alarm": {
+        "path": "rtc/rtc_alarm",
+        "name": "rtc_alarm",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w"
+        ],
+        "supportRiscV": false
+    },
+    "hello_rtc": {
+        "path": "rtc/hello_rtc",
+        "name": "hello_rtc",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w"
+        ],
+        "supportRiscV": false
+    },
+    "rtc_alarm_repeat": {
+        "path": "rtc/rtc_alarm_repeat",
+        "name": "rtc_alarm_repeat",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w"
+        ],
+        "supportRiscV": false
+    },
+    "multicore_fifo_irqs": {
+        "path": "multicore/multicore_fifo_irqs",
+        "name": "multicore_fifo_irqs",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w"
+        ],
+        "supportRiscV": false
+    },
+    "multicore_runner": {
+        "path": "multicore/multicore_runner",
+        "name": "multicore_runner",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "multicore_runner_queue": {
+        "path": "multicore/multicore_runner_queue",
+        "name": "multicore_runner_queue",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_multicore": {
+        "path": "multicore/hello_multicore",
+        "name": "hello_multicore",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_reset": {
+        "path": "reset/hello_reset",
+        "name": "hello_reset",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_interp": {
+        "path": "interp/hello_interp",
+        "name": "hello_interp",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "mpl3115a2_i2c": {
+        "path": "i2c/mpl3115a2_i2c",
+        "name": "mpl3115a2_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "mcp9808_i2c": {
+        "path": "i2c/mcp9808_i2c",
+        "name": "mcp9808_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "mpu6050_i2c": {
+        "path": "i2c/mpu6050_i2c",
+        "name": "mpu6050_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pa1010d_i2c": {
+        "path": "i2c/pa1010d_i2c",
+        "name": "pa1010d_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "lis3dh_i2c": {
+        "path": "i2c/lis3dh_i2c",
+        "name": "lis3dh_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "mma8451_i2c": {
+        "path": "i2c/mma8451_i2c",
+        "name": "mma8451_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "ht16k33_i2c": {
+        "path": "i2c/ht16k33_i2c",
+        "name": "ht16k33_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "i2c_bus_scan": {
+        "path": "i2c/bus_scan",
+        "name": "bus_scan",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "pcf8523_i2c": {
+        "path": "i2c/pcf8523_i2c",
+        "name": "pcf8523_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "lcd_1602_i2c": {
+        "path": "i2c/lcd_1602_i2c",
+        "name": "lcd_1602_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "bmp280_i2c": {
+        "path": "i2c/bmp280_i2c",
+        "name": "bmp280_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "slave_mem_i2c": {
+        "path": "i2c/slave_mem_i2c",
+        "name": "slave_mem_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "ssd1306_i2c": {
+        "path": "i2c/ssd1306_i2c",
+        "name": "ssd1306_i2c",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "adc_dma_capture": {
+        "path": "adc/dma_capture",
+        "name": "dma_capture",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "joystick_display": {
+        "path": "adc/joystick_display",
+        "name": "joystick_display",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "onboard_temperature": {
+        "path": "adc/onboard_temperature",
+        "name": "onboard_temperature",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "microphone_adc": {
+        "path": "adc/microphone_adc",
+        "name": "microphone_adc",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "adc_console": {
+        "path": "adc/adc_console",
+        "name": "adc_console",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "read_vsys": {
+        "path": "adc/read_vsys",
+        "name": "read_vsys",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_adc": {
+        "path": "adc/hello_adc",
+        "name": "hello_adc",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "sniff_crc": {
+        "path": "dma/sniff_crc",
+        "name": "sniff_crc",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "dma_control_blocks": {
+        "path": "dma/control_blocks",
+        "name": "control_blocks",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_dma": {
+        "path": "dma/hello_dma",
+        "name": "hello_dma",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "dma_channel_irq": {
+        "path": "dma/channel_irq",
+        "name": "channel_irq",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "spi_dma": {
+        "path": "spi/spi_dma",
+        "name": "spi_dma",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "spi_flash": {
+        "path": "spi/spi_flash",
+        "name": "spi_flash",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "mpu9250_spi": {
+        "path": "spi/mpu9250_spi",
+        "name": "mpu9250_spi",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "max7219_8x7seg_spi": {
+        "path": "spi/max7219_8x7seg_spi",
+        "name": "max7219_8x7seg_spi",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "max7219_32x8_spi": {
+        "path": "spi/max7219_32x8_spi",
+        "name": "max7219_32x8_spi",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "bme280_spi": {
+        "path": "spi/bme280_spi",
+        "name": "bme280_spi",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "spi_master": {
+        "path": "spi/spi_master_slave/spi_master",
+        "name": "spi_master",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "spi_slave": {
+        "path": "spi/spi_master_slave/spi_slave",
+        "name": "spi_slave",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico",
+            "pico_w",
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "picow_blink": {
+        "path": "pico_w/wifi/blink",
+        "name": "blink",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico_w"
+        ],
+        "supportRiscV": false
+    },
+    "picow_blink_slow_clock": {
+        "path": "pico_w/wifi/blink",
+        "name": "blink",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico_w"
+        ],
+        "supportRiscV": false
+    },
+    "picow_ble_temp_reader": {
+        "path": "pico_w/bt/standalone",
+        "name": "standalone",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico_w"
+        ],
+        "supportRiscV": false
+    },
+    "picow_ble_temp_sensor": {
+        "path": "pico_w/bt/standalone",
+        "name": "standalone",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico_w"
+        ],
+        "supportRiscV": false
+    },
+    "hello_sha256": {
+        "path": "sha/sha256",
+        "name": "sha256",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "mbedtls_sha256": {
+        "path": "sha/mbedtls_sha256",
+        "name": "mbedtls_sha256",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "boot_info": {
+        "path": "system/boot_info",
+        "name": "boot_info",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "runtime_flash_permissions": {
+        "path": "flash/runtime_flash_permissions",
+        "name": "runtime_flash_permissions",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "multicore_doorbell": {
+        "path": "multicore/multicore_doorbell",
+        "name": "multicore_doorbell",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico2"
+        ],
+        "supportRiscV": true
+    },
+    "hello_dcp": {
+        "path": "dcp/hello_dcp",
+        "name": "hello_dcp",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico2"
+        ],
+        "supportRiscV": false
+    },
+    "hello_otp": {
+        "path": "otp/hello_otp",
+        "name": "hello_otp",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico2"
+        ],
+        "supportRiscV": true
+    }
+}

--- a/data/0.16.0/examples.json
+++ b/data/0.16.0/examples.json
@@ -1,7 +1,7 @@
 {
     "hello_usb": {
         "path": "hello_world/usb",
-        "name": "usb",
+        "name": "hello_usb",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -13,7 +13,7 @@
     },
     "hello_serial": {
         "path": "hello_world/serial",
-        "name": "serial",
+        "name": "hello_serial",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -25,7 +25,7 @@
     },
     "pwm_led_fade": {
         "path": "pwm/led_fade",
-        "name": "led_fade",
+        "name": "pwm_led_fade",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -48,7 +48,7 @@
     },
     "pwm_measure_duty_cycle": {
         "path": "pwm/measure_duty_cycle",
-        "name": "measure_duty_cycle",
+        "name": "pwm_measure_duty_cycle",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -84,7 +84,7 @@
     },
     "clocks_detached_clk_peri": {
         "path": "clocks/detached_clk_peri",
-        "name": "detached_clk_peri",
+        "name": "clocks_detached_clk_peri",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -144,7 +144,7 @@
     },
     "dht": {
         "path": "gpio/dht_sensor",
-        "name": "dht_sensor",
+        "name": "dht",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -216,7 +216,7 @@
     },
     "pio_hub75": {
         "path": "pio/hub75",
-        "name": "hub75",
+        "name": "pio_hub75",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -228,7 +228,7 @@
     },
     "pio_pwm": {
         "path": "pio/pwm",
-        "name": "pwm",
+        "name": "pio_pwm",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -239,7 +239,7 @@
     },
     "pio_manchester_encoding": {
         "path": "pio/manchester_encoding",
-        "name": "manchester_encoding",
+        "name": "pio_manchester_encoding",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -251,7 +251,7 @@
     },
     "pio_differential_manchester": {
         "path": "pio/differential_manchester",
-        "name": "differential_manchester",
+        "name": "pio_differential_manchester",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -263,7 +263,7 @@
     },
     "pio_addition": {
         "path": "pio/addition",
-        "name": "addition",
+        "name": "pio_addition",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -275,7 +275,7 @@
     },
     "pio_onewire": {
         "path": "pio/onewire",
-        "name": "onewire",
+        "name": "pio_onewire",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -287,7 +287,7 @@
     },
     "pio_squarewave": {
         "path": "pio/squarewave",
-        "name": "squarewave",
+        "name": "pio_squarewave",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -299,7 +299,7 @@
     },
     "pio_squarewave_div_sync": {
         "path": "pio/squarewave",
-        "name": "squarewave",
+        "name": "pio_squarewave_div_sync",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -311,7 +311,7 @@
     },
     "pio_clocked_input": {
         "path": "pio/clocked_input",
-        "name": "clocked_input",
+        "name": "pio_clocked_input",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -335,7 +335,7 @@
     },
     "pio_quadrature_encoder_substep": {
         "path": "pio/quadrature_encoder_substep",
-        "name": "quadrature_encoder_substep",
+        "name": "pio_quadrature_encoder_substep",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -347,7 +347,7 @@
     },
     "pio_quadrature_encoder": {
         "path": "pio/quadrature_encoder",
-        "name": "quadrature_encoder",
+        "name": "pio_quadrature_encoder",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -359,7 +359,7 @@
     },
     "pio_ws2812": {
         "path": "pio/ws2812",
-        "name": "ws2812",
+        "name": "pio_ws2812",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -371,7 +371,7 @@
     },
     "pio_uart_rx": {
         "path": "pio/uart_rx",
-        "name": "uart_rx",
+        "name": "pio_uart_rx",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -383,7 +383,7 @@
     },
     "pio_uart_rx_intr": {
         "path": "pio/uart_rx",
-        "name": "uart_rx",
+        "name": "pio_uart_rx_intr",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -395,7 +395,7 @@
     },
     "pio_logic_analyser": {
         "path": "pio/logic_analyser",
-        "name": "logic_analyser",
+        "name": "pio_logic_analyser",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -407,7 +407,7 @@
     },
     "pio_ir_loopback": {
         "path": "pio/ir_nec/ir_loopback",
-        "name": "ir_loopback",
+        "name": "pio_ir_loopback",
         "libPaths": [
             "pio/ir_nec/nec_receive_library",
             "pio/ir_nec/nec_transmit_library"
@@ -425,7 +425,7 @@
     },
     "pio_i2c_bus_scan": {
         "path": "pio/i2c",
-        "name": "i2c",
+        "name": "pio_i2c_bus_scan",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -437,7 +437,7 @@
     },
     "pio_spi_flash": {
         "path": "pio/spi",
-        "name": "spi",
+        "name": "pio_spi_flash",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -449,7 +449,7 @@
     },
     "pio_spi_loopback": {
         "path": "pio/spi",
-        "name": "spi",
+        "name": "pio_spi_loopback",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -461,7 +461,7 @@
     },
     "pio_apa102": {
         "path": "pio/apa102",
-        "name": "apa102",
+        "name": "pio_apa102",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -473,7 +473,7 @@
     },
     "pio_uart_tx": {
         "path": "pio/uart_tx",
-        "name": "uart_tx",
+        "name": "pio_uart_tx",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -485,7 +485,7 @@
     },
     "pio_st7789_lcd": {
         "path": "pio/st7789_lcd",
-        "name": "st7789_lcd",
+        "name": "pio_st7789_lcd",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -508,7 +508,7 @@
     },
     "picoboard_button": {
         "path": "picoboard/button",
-        "name": "button",
+        "name": "picoboard_button",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -519,7 +519,7 @@
     },
     "picoboard_blinky": {
         "path": "picoboard/blinky",
-        "name": "blinky",
+        "name": "picoboard_blinky",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -530,7 +530,7 @@
     },
     "hello_divider": {
         "path": "divider",
-        "name": "divider",
+        "name": "hello_divider",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -590,7 +590,7 @@
     },
     "flash_program": {
         "path": "flash/program",
-        "name": "program",
+        "name": "flash_program",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -602,7 +602,7 @@
     },
     "flash_xip_stream": {
         "path": "flash/xip_stream",
-        "name": "xip_stream",
+        "name": "flash_xip_stream",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -614,7 +614,7 @@
     },
     "flash_ssi_dma": {
         "path": "flash/ssi_dma",
-        "name": "ssi_dma",
+        "name": "flash_ssi_dma",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -625,7 +625,7 @@
     },
     "flash_nuke": {
         "path": "flash/nuke",
-        "name": "nuke",
+        "name": "flash_nuke",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -637,7 +637,7 @@
     },
     "flash_cache_perfctr": {
         "path": "flash/cache_perfctr",
-        "name": "cache_perfctr",
+        "name": "flash_cache_perfctr",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -908,7 +908,7 @@
     },
     "i2c_bus_scan": {
         "path": "i2c/bus_scan",
-        "name": "bus_scan",
+        "name": "i2c_bus_scan",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -980,7 +980,7 @@
     },
     "adc_dma_capture": {
         "path": "adc/dma_capture",
-        "name": "dma_capture",
+        "name": "adc_dma_capture",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -1076,7 +1076,7 @@
     },
     "dma_control_blocks": {
         "path": "dma/control_blocks",
-        "name": "control_blocks",
+        "name": "dma_control_blocks",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -1100,7 +1100,7 @@
     },
     "dma_channel_irq": {
         "path": "dma/channel_irq",
-        "name": "channel_irq",
+        "name": "dma_channel_irq",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -1207,7 +1207,7 @@
     },
     "picow_blink": {
         "path": "pico_w/wifi/blink",
-        "name": "blink",
+        "name": "picow_blink",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -1217,7 +1217,7 @@
     },
     "picow_blink_slow_clock": {
         "path": "pico_w/wifi/blink",
-        "name": "blink",
+        "name": "picow_blink_slow_clock",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -1227,7 +1227,7 @@
     },
     "picow_ble_temp_reader": {
         "path": "pico_w/bt/standalone",
-        "name": "standalone",
+        "name": "picow_ble_temp_reader",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -1237,7 +1237,7 @@
     },
     "picow_ble_temp_sensor": {
         "path": "pico_w/bt/standalone",
-        "name": "standalone",
+        "name": "picow_ble_temp_sensor",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -1247,7 +1247,7 @@
     },
     "hello_sha256": {
         "path": "sha/sha256",
-        "name": "sha256",
+        "name": "hello_sha256",
         "libPaths": [],
         "libNames": [],
         "boards": [
@@ -1264,6 +1264,26 @@
             "pico2"
         ],
         "supportRiscV": true
+    },
+    "enc_bootloader": {
+        "path": "bootloaders/encrypted",
+        "name": "enc_bootloader",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico2"
+        ],
+        "supportRiscV": false
+    },
+    "hello_serial_enc": {
+        "path": "bootloaders/encrypted",
+        "name": "hello_serial_enc",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [
+            "pico2"
+        ],
+        "supportRiscV": false
     },
     "boot_info": {
         "path": "system/boot_info",

--- a/data/0.16.0/github-cache.json
+++ b/data/0.16.0/github-cache.json
@@ -1,0 +1,387 @@
+{
+  "githubApiCache-0-0": [
+    "1.5.1",
+    "2.0.0"
+  ],
+  "githubApiCache-0-1-1.5.1": {
+    "assets": [
+      {
+        "id": 112935743,
+        "name": "sdk-1.5.1-html-doc.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk/releases/download/1.5.1/sdk-1.5.1-html-doc.zip"
+      }
+    ],
+    "assetsUrl": "https://api.github.com/repos/raspberrypi/pico-sdk/releases/107707260/assets"
+  },
+  "githubApiCache-0-1-2.0.0": {
+    "assets": [
+      {
+        "id": 184711853,
+        "name": "pico-sdk-2.0.0.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk/releases/download/2.0.0/pico-sdk-2.0.0.tar.gz"
+      }
+    ],
+    "assetsUrl": "https://api.github.com/repos/raspberrypi/pico-sdk/releases/169292056/assets"
+  },
+  "githubApiCache-1-0": [
+    "v3.28.6",
+    "v3.29.6"
+  ],
+  "githubApiCache-1-1-v3.28.6": {
+    "assets": [
+      {
+        "id": 171682637,
+        "name": "cmake-3.28.6-files-v1.json",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-files-v1.json"
+      },
+      {
+        "id": 171682639,
+        "name": "cmake-3.28.6-linux-aarch64.sh",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-linux-aarch64.sh"
+      },
+      {
+        "id": 171682797,
+        "name": "cmake-3.28.6-linux-aarch64.tar.gz",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-linux-aarch64.tar.gz"
+      },
+      {
+        "id": 171682872,
+        "name": "cmake-3.28.6-linux-x86_64.sh",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-linux-x86_64.sh"
+      },
+      {
+        "id": 171682906,
+        "name": "cmake-3.28.6-linux-x86_64.tar.gz",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-linux-x86_64.tar.gz"
+      },
+      {
+        "id": 171682946,
+        "name": "cmake-3.28.6-macos-universal.dmg",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-macos-universal.dmg"
+      },
+      {
+        "id": 171683083,
+        "name": "cmake-3.28.6-macos-universal.tar.gz",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-macos-universal.tar.gz"
+      },
+      {
+        "id": 171683266,
+        "name": "cmake-3.28.6-macos10.10-universal.dmg",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-macos10.10-universal.dmg"
+      },
+      {
+        "id": 171683323,
+        "name": "cmake-3.28.6-macos10.10-universal.tar.gz",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-macos10.10-universal.tar.gz"
+      },
+      {
+        "id": 171683404,
+        "name": "cmake-3.28.6-SHA-256.txt",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-SHA-256.txt"
+      },
+      {
+        "id": 171683405,
+        "name": "cmake-3.28.6-SHA-256.txt.asc",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-SHA-256.txt.asc"
+      },
+      {
+        "id": 171683406,
+        "name": "cmake-3.28.6-windows-arm64.msi",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-windows-arm64.msi"
+      },
+      {
+        "id": 171683440,
+        "name": "cmake-3.28.6-windows-arm64.zip",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-windows-arm64.zip"
+      },
+      {
+        "id": 171683535,
+        "name": "cmake-3.28.6-windows-i386.msi",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-windows-i386.msi"
+      },
+      {
+        "id": 171683624,
+        "name": "cmake-3.28.6-windows-i386.zip",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-windows-i386.zip"
+      },
+      {
+        "id": 171683745,
+        "name": "cmake-3.28.6-windows-x86_64.msi",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-windows-x86_64.msi"
+      },
+      {
+        "id": 171683767,
+        "name": "cmake-3.28.6-windows-x86_64.zip",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-windows-x86_64.zip"
+      },
+      {
+        "id": 171683790,
+        "name": "cmake-3.28.6.tar.gz",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6.tar.gz"
+      },
+      {
+        "id": 171683796,
+        "name": "cmake-3.28.6.zip",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6.zip"
+      }
+    ],
+    "assetsUrl": "https://api.github.com/repos/Kitware/CMake/releases/158667625/assets"
+  },
+  "githubApiCache-1-1-v3.29.6": {
+    "assets": [
+      {
+        "id": 174341995,
+        "name": "cmake-3.29.6-files-v1.json",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-files-v1.json"
+      },
+      {
+        "id": 174341999,
+        "name": "cmake-3.29.6-linux-aarch64.sh",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-linux-aarch64.sh"
+      },
+      {
+        "id": 174342062,
+        "name": "cmake-3.29.6-linux-aarch64.tar.gz",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-linux-aarch64.tar.gz"
+      },
+      {
+        "id": 174342111,
+        "name": "cmake-3.29.6-linux-x86_64.sh",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-linux-x86_64.sh"
+      },
+      {
+        "id": 174347312,
+        "name": "cmake-3.29.6-linux-x86_64.tar.gz",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-linux-x86_64.tar.gz"
+      },
+      {
+        "id": 174342299,
+        "name": "cmake-3.29.6-macos-universal.dmg",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-macos-universal.dmg"
+      },
+      {
+        "id": 174342411,
+        "name": "cmake-3.29.6-macos-universal.tar.gz",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-macos-universal.tar.gz"
+      },
+      {
+        "id": 174342498,
+        "name": "cmake-3.29.6-macos10.10-universal.dmg",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-macos10.10-universal.dmg"
+      },
+      {
+        "id": 174342661,
+        "name": "cmake-3.29.6-macos10.10-universal.tar.gz",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-macos10.10-universal.tar.gz"
+      },
+      {
+        "id": 174342833,
+        "name": "cmake-3.29.6-SHA-256.txt",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-SHA-256.txt"
+      },
+      {
+        "id": 174342839,
+        "name": "cmake-3.29.6-SHA-256.txt.asc",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-SHA-256.txt.asc"
+      },
+      {
+        "id": 174342841,
+        "name": "cmake-3.29.6-windows-arm64.msi",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-windows-arm64.msi"
+      },
+      {
+        "id": 174342900,
+        "name": "cmake-3.29.6-windows-arm64.zip",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-windows-arm64.zip"
+      },
+      {
+        "id": 174342965,
+        "name": "cmake-3.29.6-windows-i386.msi",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-windows-i386.msi"
+      },
+      {
+        "id": 174342982,
+        "name": "cmake-3.29.6-windows-i386.zip",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-windows-i386.zip"
+      },
+      {
+        "id": 174343004,
+        "name": "cmake-3.29.6-windows-x86_64.msi",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-windows-x86_64.msi"
+      },
+      {
+        "id": 174343044,
+        "name": "cmake-3.29.6-windows-x86_64.zip",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6-windows-x86_64.zip"
+      },
+      {
+        "id": 174343086,
+        "name": "cmake-3.29.6.tar.gz",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6.tar.gz"
+      },
+      {
+        "id": 174343102,
+        "name": "cmake-3.29.6.zip",
+        "browser_download_url": "https://github.com/Kitware/CMake/releases/download/v3.29.6/cmake-3.29.6.zip"
+      }
+    ],
+    "assetsUrl": "https://api.github.com/repos/Kitware/CMake/releases/160931478/assets"
+  },
+  "githubApiCache-2-0": [
+    "v1.12.1"
+  ],
+  "githubApiCache-2-1-v1.12.1": {
+    "assets": [
+      {
+        "id": 167333823,
+        "name": "ninja-linux-aarch64.zip",
+        "browser_download_url": "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux-aarch64.zip"
+      },
+      {
+        "id": 167333509,
+        "name": "ninja-linux.zip",
+        "browser_download_url": "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip"
+      },
+      {
+        "id": 167333196,
+        "name": "ninja-mac.zip",
+        "browser_download_url": "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-mac.zip"
+      },
+      {
+        "id": 167333379,
+        "name": "ninja-win.zip",
+        "browser_download_url": "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip"
+      },
+      {
+        "id": 167333478,
+        "name": "ninja-winarm64.zip",
+        "browser_download_url": "https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-winarm64.zip"
+      }
+    ],
+    "assetsUrl": "https://api.github.com/repos/ninja-build/ninja/releases/155357494/assets"
+  },
+  "githubApiCache-3-0": [
+    "v1.5.1-0",
+    "v2.0.0-0"
+  ],
+  "githubApiCache-3-1-v1.5.1-0": {
+    "assets": [
+      {
+        "id": 184737292,
+        "name": "openocd-0.12.0+dev-aarch64-lin.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v1.5.1-0/openocd-0.12.0%2Bdev-aarch64-lin.tar.gz"
+      },
+      {
+        "id": 184736619,
+        "name": "openocd-0.12.0+dev-arm64-mac.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v1.5.1-0/openocd-0.12.0%2Bdev-arm64-mac.zip"
+      },
+      {
+        "id": 184739207,
+        "name": "openocd-0.12.0+dev-x64-win.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v1.5.1-0/openocd-0.12.0%2Bdev-x64-win.zip"
+      },
+      {
+        "id": 184736698,
+        "name": "openocd-0.12.0+dev-x86_64-lin.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v1.5.1-0/openocd-0.12.0%2Bdev-x86_64-lin.tar.gz"
+      },
+      {
+        "id": 184739206,
+        "name": "pico-sdk-tools-1.5.1-x64-win.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v1.5.1-0/pico-sdk-tools-1.5.1-x64-win.zip"
+      },
+      {
+        "id": 184737290,
+        "name": "picotool-2.0.0-aarch64-lin.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v1.5.1-0/picotool-2.0.0-aarch64-lin.tar.gz"
+      },
+      {
+        "id": 184736618,
+        "name": "picotool-2.0.0-mac.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v1.5.1-0/picotool-2.0.0-mac.zip"
+      },
+      {
+        "id": 184739208,
+        "name": "picotool-2.0.0-x64-win.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v1.5.1-0/picotool-2.0.0-x64-win.zip"
+      },
+      {
+        "id": 184736697,
+        "name": "picotool-2.0.0-x86_64-lin.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v1.5.1-0/picotool-2.0.0-x86_64-lin.tar.gz"
+      }
+    ],
+    "assetsUrl": "https://api.github.com/repos/raspberrypi/pico-sdk-tools/releases/169373034/assets"
+  },
+  "githubApiCache-3-1-v2.0.0-0": {
+    "assets": [
+      {
+        "id": 184711252,
+        "name": "openocd-0.12.0+dev-aarch64-lin.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/openocd-0.12.0%2Bdev-aarch64-lin.tar.gz"
+      },
+      {
+        "id": 184710255,
+        "name": "openocd-0.12.0+dev-arm64-mac.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/openocd-0.12.0%2Bdev-arm64-mac.zip"
+      },
+      {
+        "id": 184711712,
+        "name": "openocd-0.12.0+dev-x64-win.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/openocd-0.12.0%2Bdev-x64-win.zip"
+      },
+      {
+        "id": 184709989,
+        "name": "openocd-0.12.0+dev-x86_64-lin.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/openocd-0.12.0%2Bdev-x86_64-lin.tar.gz"
+      },
+      {
+        "id": 184711250,
+        "name": "pico-sdk-tools-2.0.0-aarch64-lin.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/pico-sdk-tools-2.0.0-aarch64-lin.tar.gz"
+      },
+      {
+        "id": 184710252,
+        "name": "pico-sdk-tools-2.0.0-mac.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/pico-sdk-tools-2.0.0-mac.zip"
+      },
+      {
+        "id": 184711713,
+        "name": "pico-sdk-tools-2.0.0-x64-win.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/pico-sdk-tools-2.0.0-x64-win.zip"
+      },
+      {
+        "id": 184709990,
+        "name": "pico-sdk-tools-2.0.0-x86_64-lin.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/pico-sdk-tools-2.0.0-x86_64-lin.tar.gz"
+      },
+      {
+        "id": 184711251,
+        "name": "picotool-2.0.0-aarch64-lin.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/picotool-2.0.0-aarch64-lin.tar.gz"
+      },
+      {
+        "id": 184710253,
+        "name": "picotool-2.0.0-mac.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/picotool-2.0.0-mac.zip"
+      },
+      {
+        "id": 184711714,
+        "name": "picotool-2.0.0-x64-win.zip",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/picotool-2.0.0-x64-win.zip"
+      },
+      {
+        "id": 184709988,
+        "name": "picotool-2.0.0-x86_64-lin.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/picotool-2.0.0-x86_64-lin.tar.gz"
+      },
+      {
+        "id": 184716562,
+        "name": "riscv-toolchain-14-aarch64-lin.tar.gz",
+        "browser_download_url": "https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/riscv-toolchain-14-aarch64-lin.tar.gz"
+      }
+    ],
+    "assetsUrl": "https://api.github.com/repos/raspberrypi/pico-sdk-tools/releases/169351844/assets"
+  }
+}

--- a/data/0.16.0/supportedToolchains.ini
+++ b/data/0.16.0/supportedToolchains.ini
@@ -1,0 +1,36 @@
+[13_2_Rel1]
+win32_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-mingw-w64-i686-arm-none-eabi.zip
+darwin_arm64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-arm64-arm-none-eabi.tar.xz
+darwin_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz
+linux_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-x86_64-arm-none-eabi.tar.xz
+linux_arm64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/13.2.rel1/binrel/arm-gnu-toolchain-13.2.rel1-aarch64-arm-none-eabi.tar.xz
+[RISCV_13_3]
+win32_x64 = https://buildbot.embecosm.com/job/riscv32-gcc-win64-release/24/artifact/riscv32-embecosm-win64-gcc13.2.0.zip
+darwin_arm64 = https://buildbot.embecosm.com/job/riscv32-gcc-macos-arm64-release/10/artifact/riscv32-embecosm-macos-gcc13.3.0.zip
+darwin_x64 = https://buildbot.embecosm.com/job/riscv32-gcc-macos-release/21/artifact/riscv32-embecosm-macos-gcc13.3.0.zip
+linux_x64 = https://buildbot.embecosm.com/job/riscv32-gcc-ubuntu2204-release/12/artifact/riscv32-embecosm-ubuntu2204-gcc13.3.0.tar.gz
+[RISCV_COREV_MAY_24]
+win32_x64 = https://buildbot.embecosm.com/job/corev-gcc-win64/50/artifact/corev-openhw-gcc-win64-20240602.zip
+darwin_arm64 = https://buildbot.embecosm.com/job/corev-gcc-macos-arm64/8/artifact/corev-openhw-gcc-macos-20240530.zip
+darwin_x64 = https://buildbot.embecosm.com/job/corev-gcc-macos/48/artifact/corev-openhw-gcc-macos-20240530.zip
+linux_x64 = https://buildbot.embecosm.com/job/corev-gcc-ubuntu2204/47/artifact/corev-openhw-gcc-ubuntu2204-20240530.tar.gz
+[RISCV_RPI]
+linux_arm64 = https://github.com/raspberrypi/pico-sdk-tools/releases/download/v2.0.0-0/riscv-toolchain-14-aarch64-lin.tar.gz
+[12_3_Rel1]
+win32_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-mingw-w64-i686-arm-none-eabi.zip
+darwin_arm64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-darwin-arm64-arm-none-eabi.tar.xz
+darwin_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz
+linux_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-x86_64-arm-none-eabi.tar.xz
+linux_arm64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.3.rel1/binrel/arm-gnu-toolchain-12.3.rel1-aarch64-arm-none-eabi.tar.xz
+[12_2_Rel1]
+win32_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-mingw-w64-i686-arm-none-eabi.zip
+darwin_arm64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-darwin-arm64-arm-none-eabi.tar.xz
+darwin_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-darwin-x86_64-arm-none-eabi.tar.xz
+linux_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-arm-none-eabi.tar.xz
+linux_arm64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-aarch64-arm-none-eabi.tar.xz
+[11_3_Rel1]
+win32_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-mingw-w64-i686-arm-none-eabi.zip
+darwin_arm64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-darwin-arm64-arm-none-eabi.tar.xz
+darwin_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-darwin-x86_64-arm-none-eabi.tar.xz
+linux_x64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-eabi.tar.xz
+linux_arm64 = https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-aarch64-arm-none-eabi.tar.xz

--- a/data/0.16.0/versionBundles.json
+++ b/data/0.16.0/versionBundles.json
@@ -1,0 +1,35 @@
+{
+  "1.5.0": {
+    "python": {
+      "version": "3.9.13",
+      "macos": "https://www.python.org/ftp/python/3.9.13/python-3.9.13-macos11.pkg",
+      "windowsAmd64": "https://www.python.org/ftp/python/3.9.13/python-3.9.13-embed-amd64.zip"
+    },
+    "ninja": "v1.12.1",
+    "cmake": "v3.28.6",
+    "toolchain": "12_3_Rel1",
+    "riscvToolchain": "NONE"
+  },
+  "1.5.1": {
+    "python": {
+      "version": "3.12.1",
+      "macos": "https://www.python.org/ftp/python/3.12.1/python-3.12.1-macos11.pkg",
+      "windowsAmd64": "https://www.python.org/ftp/python/3.12.1/python-3.12.1-embed-amd64.zip"
+    },
+    "ninja": "v1.12.1",
+    "cmake": "v3.28.6",
+    "toolchain": "13_2_Rel1",
+    "riscvToolchain": "NONE"
+  },
+  "2.0.0": {
+    "python": {
+      "version": "3.12.1",
+      "macos": "https://www.python.org/ftp/python/3.12.1/python-3.12.1-macos11.pkg",
+      "windowsAmd64": "https://www.python.org/ftp/python/3.12.1/python-3.12.1-embed-amd64.zip"
+    },
+    "ninja": "v1.12.1",
+    "cmake": "v3.28.6",
+    "toolchain": "13_2_Rel1",
+    "riscvToolchain": "RISCV_COREV_MAY_24"
+  }
+}

--- a/scripts/genExamples.py
+++ b/scripts/genExamples.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import shutil
+import json
+
+from pico_project import GenerateCMake
+
+boards = [
+    "pico",
+    "pico_w",
+    "pico2"
+]
+
+platforms = {
+    "pico": ["rp2040"],
+    "pico_w": ["rp2040"],
+    "pico2": [
+        "rp2350-arm-s",
+        "rp2350-riscv"
+    ]
+}
+
+examples = {
+    "example_format": {
+        "path": "hello_world/usb",
+        "name": "usb",
+        "libPaths": [],
+        "libNames": [],
+        "boards": [],
+        "supportRiscV": False
+    }
+}
+
+examples.clear()
+
+CURRENT_DATA_VERSION = "0.16.0"
+
+for board in boards:
+    for platform in platforms[board]:
+        try:
+            shutil.rmtree("build")
+        except FileNotFoundError:
+            pass
+        toolchainVersion = "RISCV_COREV_MAY_24" if "riscv" in platform else "13_2_Rel1"
+        toolchainPath = f"~/.pico-sdk/toolchain/{toolchainVersion}"
+        os.system(f"cmake -S pico-examples -B build -DPICO_BOARD={board} -DPICO_PLATFORM={platform} -DPICO_TOOLCHAIN_PATH={toolchainPath}")
+
+        os.system("cmake --build build --target help > targets.txt")
+
+        targets = []
+
+        with open("targets.txt", "r") as f:
+            for line in f.readlines():
+                target = line.strip('.').strip()
+                if (
+                    "all" in target or
+                    target == "clean" or
+                    target == "depend" or
+                    target == "edit_cache" or
+                    target == "rebuild_cache" or
+                    target.endswith("_pio_h")
+                ):
+                    continue
+                targets.append(target)
+
+        print(targets)
+
+        walk_dir = "./pico-examples"
+
+        print('walk_dir (absolute) = ' + os.path.abspath(walk_dir))
+
+        target_locs = {}
+        lib_locs = {}
+
+        for root, subdirs, files in os.walk(walk_dir):
+            for filename in files:
+                if filename != "CMakeLists.txt":
+                    continue
+                file_path = os.path.join(root, filename)
+
+                with open(file_path, 'r') as f:
+                    f_content = f.read()
+                    if "add_library" in f_content:
+                        for target in targets:
+                            if f"add_library({target}" in f_content:
+                                tmp = lib_locs.get(target, {
+                                    "locs": []
+                                })
+                                tmp["locs"].append(file_path)
+                                lib_locs[target] = tmp
+                    if "add_executable" in f_content:
+                        print('\t- file %s (full path: %s)' % (filename, file_path))
+                        exes = []
+                        for target in targets:
+                            if f"example_auto_set_url({target})" in f_content:
+                                exes.append(target)
+                                tmp = target_locs.get(target, {
+                                    "locs": [],
+                                    "libs": []
+                                })
+                                tmp["locs"].append(file_path)
+                                target_locs[target] = tmp
+                        if len(exes):
+                            print("Has executables", exes)
+
+        for k, v in target_locs.items():
+            if len(v["locs"]) > 1:
+                raise ValueError(f"Too many locs {v}")
+            target_locs[k]["loc"] = v["locs"][0]
+            with open(v["locs"][0], "r") as f:
+                f_content = f.read()
+                for lib in lib_locs:
+                    if lib in f_content:
+                        target_locs[k]["libs"].append(lib)
+
+        print("Libs")
+
+        for k, v in lib_locs.items():
+            if len(v["locs"]) > 1:
+                raise ValueError(f"Too many locs {v}")
+            lib_locs[k]["loc"] = v["locs"][0]
+            print(k, v)
+
+        print("Targets with libs")
+
+        # to_del = []
+        for k, v in target_locs.items():
+            if len(v["libs"]) > 0:
+                print(k, v)
+            # else:
+            #     to_del.append(k)
+        # for k in to_del:
+        #     del target_locs[k]
+
+        # Test build them all
+        try:
+            shutil.rmtree("tmp")
+            shutil.rmtree("tmp-build")
+        except FileNotFoundError:
+            pass
+        for target, v in target_locs.items():
+            os.mkdir("tmp-build")
+            loc = v["loc"]
+            loc = loc.replace("/CMakeLists.txt", "")
+            shutil.copytree(loc, "tmp")
+            if len(v["libs"]):
+                for lib in v["libs"]:
+                    shutil.copytree(
+                        lib_locs[lib]["loc"].replace("/CMakeLists.txt", ""),
+                        f"tmp/{lib}"
+                    )
+            params={
+                'projectName'   : target,
+                'wantOverwrite' : True,
+                'wantConvert'   : True,
+                'wantExample'   : True,
+                'wantThreadsafeBackground'  : False,
+                'wantPoll'                  : False,
+                'boardtype'     : board,
+                'sdkVersion'    : "2.0.0",
+                'toolchainVersion': toolchainVersion,
+                'picotoolVersion': "2.0.0",
+                'exampleLibs'   : v["libs"]
+            }
+            GenerateCMake("tmp", params)
+            shutil.copy("pico-examples/pico_sdk_import.cmake", "tmp/")
+
+            retcmake = os.system("cmake -S tmp -B tmp-build -DCMAKE_COMPILE_WARNING_AS_ERROR=ON")
+            retbuild = os.system("cmake --build tmp-build --parallel 22")
+            if (retcmake or retbuild):
+                print(f"Error occurred with {target} {v} - cmake {retcmake}, build {retbuild}")
+                shutil.copytree("tmp", f"errors-{board}-{platform}/{target}")
+            else:
+                if examples.get(target) != None:
+                    example = examples[target]
+                    assert(example["path"] == loc.replace(f"{walk_dir}/", ""))
+                    assert(example["name"] == loc.split('/')[-1])
+                    assert(example["libPaths"] == [lib_locs[lib]["loc"].replace("/CMakeLists.txt", "").replace(f"{walk_dir}/", "") for lib in v["libs"]])
+                    assert(example["libNames"] == v["libs"])
+                    if not board in example["boards"]:
+                        example["boards"].append(board)
+                    example["supportRiscV"] |= "riscv" in platform
+                else:
+                    examples[target] = {
+                        "path": loc.replace(f"{walk_dir}/", ""),
+                        "name": loc.split('/')[-1],
+                        "libPaths": [lib_locs[lib]["loc"].replace("/CMakeLists.txt", "").replace(f"{walk_dir}/", "") for lib in v["libs"]],
+                        "libNames": v["libs"],
+                        "boards": [board],
+                        "supportRiscV": "riscv" in platform
+                    }
+
+            shutil.rmtree("tmp")
+            shutil.rmtree("tmp-build")
+
+print(examples)
+
+with open(f"{os.path.dirname(os.path.realpath(__file__))}/../data/{CURRENT_DATA_VERSION}/examples.json", "w") as f:
+    json.dump(examples, f, indent=4)

--- a/scripts/genExamples.py
+++ b/scripts/genExamples.py
@@ -161,7 +161,7 @@ for board in boards:
                 if examples.get(target) != None:
                     example = examples[target]
                     assert(example["path"] == loc.replace(f"{walk_dir}/", ""))
-                    assert(example["name"] == loc.split('/')[-1])
+                    assert(example["name"] == target)
                     assert(example["libPaths"] == [lib_locs[lib]["loc"].replace("/CMakeLists.txt", "").replace(f"{walk_dir}/", "") for lib in v["libs"]])
                     assert(example["libNames"] == v["libs"])
                     if not board in example["boards"]:
@@ -170,7 +170,7 @@ for board in boards:
                 else:
                     examples[target] = {
                         "path": loc.replace(f"{walk_dir}/", ""),
-                        "name": loc.split('/')[-1],
+                        "name": target,
                         "libPaths": [lib_locs[lib]["loc"].replace("/CMakeLists.txt", "").replace(f"{walk_dir}/", "") for lib in v["libs"]],
                         "libNames": v["libs"],
                         "boards": [board],

--- a/scripts/genExamples.py
+++ b/scripts/genExamples.py
@@ -37,6 +37,13 @@ examples.clear()
 
 CURRENT_DATA_VERSION = "0.16.0"
 
+try:
+    shutil.rmtree("pico-examples")
+except FileNotFoundError:
+    pass
+os.system("git clone https://github.com/raspberrypi/pico-examples.git --depth=1")
+os.environ["PICO_SDK_PATH"] = "~/.pico-sdk/sdk/2.0.0"
+
 for board in boards:
     for platform in platforms[board]:
         try:
@@ -65,12 +72,7 @@ for board in boards:
                     continue
                 targets.append(target)
 
-        print(targets)
-
         walk_dir = "./pico-examples"
-
-        print('walk_dir (absolute) = ' + os.path.abspath(walk_dir))
-
         target_locs = {}
         lib_locs = {}
 
@@ -91,7 +93,6 @@ for board in boards:
                                 tmp["locs"].append(file_path)
                                 lib_locs[target] = tmp
                     if "add_executable" in f_content:
-                        print('\t- file %s (full path: %s)' % (filename, file_path))
                         exes = []
                         for target in targets:
                             if f"example_auto_set_url({target})" in f_content:
@@ -102,8 +103,6 @@ for board in boards:
                                 })
                                 tmp["locs"].append(file_path)
                                 target_locs[target] = tmp
-                        if len(exes):
-                            print("Has executables", exes)
 
         for k, v in target_locs.items():
             if len(v["locs"]) > 1:
@@ -115,24 +114,10 @@ for board in boards:
                     if lib in f_content:
                         target_locs[k]["libs"].append(lib)
 
-        print("Libs")
-
         for k, v in lib_locs.items():
             if len(v["locs"]) > 1:
                 raise ValueError(f"Too many locs {v}")
             lib_locs[k]["loc"] = v["locs"][0]
-            print(k, v)
-
-        print("Targets with libs")
-
-        # to_del = []
-        for k, v in target_locs.items():
-            if len(v["libs"]) > 0:
-                print(k, v)
-            # else:
-            #     to_del.append(k)
-        # for k in to_del:
-        #     del target_locs[k]
 
         # Test build them all
         try:
@@ -194,8 +179,6 @@ for board in boards:
 
             shutil.rmtree("tmp")
             shutil.rmtree("tmp-build")
-
-print(examples)
 
 with open(f"{os.path.dirname(os.path.realpath(__file__))}/../data/{CURRENT_DATA_VERSION}/examples.json", "w") as f:
     json.dump(examples, f, indent=4)

--- a/scripts/pico_project.py
+++ b/scripts/pico_project.py
@@ -615,12 +615,12 @@ def GenerateCMake(folder, params):
                 # Get project name
                 for line in lines:
                     if "add_executable" in line:
-                        newProjectName = line.split('(')[1].split()[0].strip().strip("()")
                         if params["wantThreadsafeBackground"] or params["wantPoll"]:
+                            newProjectName = line.split('(')[1].split()[0].strip().strip("()")
                             newProjectName = newProjectName.replace("_background", "")
                             newProjectName = newProjectName.replace("_poll", "")
-                        print("New project name", newProjectName)
-                        cmake_header2 = cmake_header2.replace(projectName, newProjectName)
+                            print("New project name", newProjectName)
+                            cmake_header2 = cmake_header2.replace(projectName, newProjectName)
                 # Write all headers
                 file.write(cmake_header1)
                 file.write(cmake_header_us)

--- a/src/utils/downloadHelpers.mts
+++ b/src/utils/downloadHelpers.mts
@@ -7,7 +7,7 @@ import AdmZip from "adm-zip";
 import { request } from "https";
 import { fileURLToPath } from "url";
 
-export const CURRENT_DATA_VERSION = "0.15.0";
+export const CURRENT_DATA_VERSION = "0.16.0";
 
 export function getDataRoot(): string {
   return joinPosix(

--- a/src/utils/examplesUtil.mts
+++ b/src/utils/examplesUtil.mts
@@ -23,7 +23,7 @@ const EXAMPLES_REPOSITORY_URL =
 const EXAMPLES_JSON_URL =
   "https://raspberrypi.github.io/pico-vscode/" +
   `${CURRENT_DATA_VERSION}/examples.json`;
-const EXAMPLES_GITREF = "7fe60d6b4027771e45d97f207532c41b1d8c5418";
+const EXAMPLES_GITREF = "175b382597cbd9d437643b024c8dd5ea18f69a7e";
 const EXAMPLES_TAG = "sdk-2.0.0";
 
 export interface Example {

--- a/src/webview/newProjectPanel.mts
+++ b/src/webview/newProjectPanel.mts
@@ -122,7 +122,6 @@ interface WebviewMessage {
 }
 
 enum BoardType {
-  default = "default",
   pico = "pico",
   picoW = "pico_w",
   pico2 = "pico2",
@@ -1390,9 +1389,9 @@ export class NewProjectPanel {
           ${
             !this._isProjectImport && this._examples.length > 0
               ? `
-          var examples = ["${this._examples
-            .map(e => e.searchKey)
-            .join('", "')}"]`
+          var examples = {${this._examples
+            .map(e => `"${e.searchKey}": {"boards": [${e.boards.map(b => `"${b}"`).join(', ')}], "supportRiscV": ${e.supportRiscV}}`)
+            .join(', ')}}`
               : ""
           }
           var doProjectImport = ${this._isProjectImport};
@@ -1506,12 +1505,6 @@ export class NewProjectPanel {
                         <div>
                             <label for="sel-board-type" class="block mb-2 text-sm font-medium text-gray-900 dark:text-white">Board type</label>
                             <select id="sel-board-type" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500">
-                                ${
-                                  // show the default option only if a use has the option to create base on an example
-                                  this._examples.length > 0
-                                    ? `<option id="sel-${BoardType.default}" value="${BoardType.default}">Default</option>`
-                                    : ""
-                                }
                                 <option id="sel-${BoardType.pico}" value="${
                           BoardType.pico
                         }">Pico</option>
@@ -1973,9 +1966,7 @@ export class NewProjectPanel {
     if ("boardType" in options) {
       try {
         boardTypeFromEnum = await enumToBoard(
-          options.boardType === BoardType.default
-            ? BoardType.pico
-            : options.boardType,
+          options.boardType,
           options.toolchainAndSDK.sdkPath
         );
       } catch {
@@ -1996,7 +1987,7 @@ export class NewProjectPanel {
               ? "-nouart"
               : "",
           ]
-        : "boardType" in options && options.boardType !== BoardType.default
+        : "boardType" in options
         ? [boardTypeFromEnum]
         : [];
     if (!("boardType" in options) && this._isProjectImport) {
@@ -2019,11 +2010,6 @@ export class NewProjectPanel {
         /* ignore */
       }
     } else if ("boardType" in options && isExampleBased && "name" in options && "libNames" in options) {
-      if (options.boardType === BoardType.default) {
-        if (options.name.includes("picow") || options.name.includes("pico_w")) {
-          basicNewProjectOptions.push(`-board pico_w`);
-        }
-      }
       for (const libName of options.libNames) {
         basicNewProjectOptions.push(`-examLibs ${libName}`);
       }

--- a/web/main.js
+++ b/web/main.js
@@ -631,6 +631,45 @@ var isPicoWireless = false;
       value: sdkVersion.replace("v", "")
     });
   });
+  document.getElementById('inp-project-name').addEventListener('input', function () {
+    if (typeof examples === 'undefined') {
+      return;
+    }
+    const projName = document.getElementById('inp-project-name').value;
+    console.log(`${projName} is now`);
+    if (!(Object.keys(examples).includes(projName))) {
+      return;
+    }
+    console.log(`${projName} is an example`);
+    // update available boards
+    const example = examples[projName];
+    const boards = example.boards;
+    for (const board of boards) {
+      console.log(`${projName} supports ${board}`);
+    }
+    const board_sels = document.querySelectorAll('[id^="sel-pico"]')
+    board_sels.forEach(e => {e.disabled = true});
+    for (const board of boards) {
+      document.getElementById(`sel-${board}`).disabled = false;
+    }
+    const boardTypeSelector = document.getElementById('sel-board-type');
+
+    if (boardTypeSelector) {
+      // first element could be hidden
+      //document.getElementById('sel-board-type').selectedIndex = 0;
+
+      // select first not hidden option
+      for (let i = 0; i < boardTypeSelector.options.length; i++) {
+        const option = boardTypeSelector.options[i];
+
+        // Check if the option is not hidden
+        if (option.style.display !== 'none' && option.hidden === false && option.disabled === false) {
+          boardTypeSelector.selectedIndex = i;
+          break;
+        }
+      }
+    }
+  });
 
   const ninjaVersionRadio = document.getElementsByName('ninja-version-radio');
   if (ninjaVersionRadio.length > 0)

--- a/web/nav.js
+++ b/web/nav.js
@@ -226,7 +226,7 @@ window.toggleCreateFromExampleMode = function (forceOn, forceOff) {
         }
 
         const isInputEmpty = projectNameInput.value === "";
-        for (let i of examples.sort()) {
+        for (let i of Object.keys(examples).sort()) {
           // startsWith was to strict for the examples name format we use
           if (isInputEmpty || i.toLowerCase().includes(projectNameInput.value.toLowerCase())) {
             // create li element
@@ -309,7 +309,7 @@ window.onload = function () {
       //const exampleOptions = Array.from(examplesList.options).map(option => option.value);
 
       const inputValue = projectNameInput.value;
-      const isValueInOptions = examples.includes(inputValue);
+      const isValueInOptions = Object.keys(examples).includes(inputValue);
 
       if (isValueInOptions) {
         // example selected


### PR DESCRIPTION
Add a proper script to generate an examples list, with boards specified for each example

This removes the need for the Default board type option, and instead greys out any unsupported boards for a given example. Bumps data version to 0.16.0, as it requires a new format for examples.json

Fixes #28 by adding support for copying those libraries too when copying the example