### PR TITLE
FIX #73, cd command need '/d' option on Windows (cmd.exe).

### DIFF
--- a/src/utils/examplesUtil.mts
+++ b/src/utils/examplesUtil.mts
@@ -174,7 +174,9 @@ export async function setupExample(
 
   if (existsSync(joinPosix(examplesRepoPath, ".git"))) {
     const ref = await execAsync(
-      `cd "${examplesRepoPath}" && ${
+      `cd ${
+        process.env.ComSpec?.endsWith("cmd.exe") ? "/d " : " "
+      }"${examplesRepoPath}" && ${
         process.env.ComSpec === "powershell.exe" ? "&" : ""
       }"${gitPath}" rev-parse HEAD`
     );

--- a/src/utils/gitUtil.mts
+++ b/src/utils/gitUtil.mts
@@ -55,8 +55,11 @@ export async function initSubmodules(
 ): Promise<boolean> {
   try {
     // Use the "git submodule update --init" command in the specified directory
+    // `cd` command need '/d' option on Windows. (Change drive "d:\" to "c:\")
     const command =
-      `cd "${sdkDirectory}" && ` +
+      `cd ${
+        process.env.ComSpec?.endsWith("cmd.exe") ? "/d " : " "
+      }"${sdkDirectory}" && ` +
       `${
         process.env.ComSpec === "powershell.exe" ? "&" : ""
       }"${gitExecutable}" submodule update --init`;
@@ -123,7 +126,9 @@ export async function sparseCloneRepository(
   try {
     await execAsync(cloneCommand);
     await execAsync(
-      `cd "${targetDirectory}" && ${
+      `cd ${
+        process.env.ComSpec?.endsWith("cmd.exe") ? "/d " : " " 
+      }"${targetDirectory}" && ${
         process.env.ComSpec === "powershell.exe" ? "&" : ""
       }"${gitExecutable}" sparse-checkout set --cone`
     );
@@ -165,7 +170,9 @@ export async function sparseCheckout(
 ): Promise<boolean> {
   try {
     await execAsync(
-      `cd "${repoDirectory}" && ${
+      `cd ${
+        process.env.ComSpec?.endsWith("cmd.exe") ? "/d " : " " 
+      } "${repoDirectory}" && ${
         process.env.ComSpec === "powershell.exe" ? "&" : ""
       }"${gitExecutable}" sparse-checkout add ${checkoutPath}`
     );


### PR DESCRIPTION
When using cmd.exe on Windows, if you need to switch to a different drive path ("c:\\" to "d:\\"), you need to use the '/d' option.

Otherwise, the following command could fails to execute:
1. `cd path && git submodule update --init`.
2. `cd path && git rev-parse HEAD`.
3. `cd path && git sparse-checkout set --cone`.
4. `cd path && git sparse-checkout add`.