### PR TITLE
Fixes openocd paths in project generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Release 1
 
+### Fixed
+- Project generator will now use bundled openocd on non-windows platforms.
+
 ## [0.16.2] - 2024-09-17
 
 ### Added

--- a/scripts/pico_project.py
+++ b/scripts/pico_project.py
@@ -792,9 +792,9 @@ def generateProjectFiles(projectPath, projectName, sdkPath, projects, debugger, 
 
     openocd_path = ""
     server_path = "\n            \"serverpath\"" # Because no \ in f-strings
-    openocd_path_os = Path(user_home, relativeOpenOCDPath(openOCDVersion).replace("/", "", 1), "openocd.exe")
+    openocd_path_os = Path(user_home, relativeOpenOCDPath(openOCDVersion).replace("/", "", 1), "openocd" + (".exe" if isWindows else ""))
     if os.path.exists(openocd_path_os):
-        openocd_path = f'{codeOpenOCDPath(openOCDVersion)}/openocd.exe'
+        openocd_path = f'{codeOpenOCDPath(openOCDVersion)}/openocd' + (".exe" if isWindows else "")
 
     for p in projects :
         if p == 'vscode':


### PR DESCRIPTION
It seems that the bundled openocd was not used after default project generation?