### PR TITLE
Add support for looking into PICO_BOARD_HEADER_DIRS custom board header

### DIFF
--- a/src/commands/launchTargetPath.mts
+++ b/src/commands/launchTargetPath.mts
@@ -3,6 +3,7 @@ import { CommandWithResult } from "./command.mjs";
 import { commands, window, workspace } from "vscode";
 import { join } from "path";
 import Settings, { SettingsKey } from "../settings.mjs";
+import { cmakeGetPicoVar } from "../utils/cmakeUtil.mjs";
 
 export default class LaunchTargetPathCommand extends CommandWithResult<string> {
   constructor() {
@@ -27,8 +28,8 @@ export default class LaunchTargetPathCommand extends CommandWithResult<string> {
 
     // Extract the project name from the matched result
     if (match && match[1]) {
-      const projectName = match[1].trim();
-
+      let projectName = match[1].trim();
+      
       if (matchBg && matchPoll) {
         // For examples with both background and poll, let user pick which to run
         const quickPickItems = ["Threadsafe Background", "Poll"];
@@ -44,6 +45,16 @@ export default class LaunchTargetPathCommand extends CommandWithResult<string> {
             return projectName + "_background";
           case quickPickItems[1]:
             return projectName + "_poll";
+        }
+      }else{
+        if(workspace.workspaceFolders !== undefined) {
+          let cmakeCacheFile = workspace.workspaceFolders[0].uri.fsPath;
+          cmakeCacheFile = join(cmakeCacheFile,"build","CMakeCache.txt");
+
+          const value = cmakeGetPicoVar(cmakeCacheFile,"CMAKE_PROJECT_NAME");
+          if(value !== null){
+            projectName = value;
+          }
         }
       }
 

--- a/src/commands/switchBoard.mts
+++ b/src/commands/switchBoard.mts
@@ -11,7 +11,7 @@ import {
   cmakeGetSelectedToolchainAndSDKVersions,
   cmakeUpdateBoard,
   cmakeUpdateSDK,
-  cmakeGetBoardHeaderDirs,
+  cmakeGetPicoVar,
 } from "../utils/cmakeUtil.mjs";
 import { join } from "path";
 import { compareLtMajor } from "../utils/semverUtil.mjs";
@@ -40,18 +40,25 @@ export default class SwitchBoardCommand extends Command {
     }
 
     const boardHeaderDirList = [];
+
+    if(workspaceFolder !== undefined) {
+      const ws = workspaceFolder.uri.fsPath;
+      const cMakeCachePath = join(ws, "build","CMakeCache.txt");
+
+      const picoBoardHeaderDirs = cmakeGetPicoVar(
+        cMakeCachePath,
+        "PICO_BOARD_HEADER_DIRS");
+
+      if(picoBoardHeaderDirs){
+        boardHeaderDirList.push(picoBoardHeaderDirs);
+      }
+    }
+
     const sdkPath = buildSDKPath(sdkVersion);
     const systemBoardHeaderDir = 
       join(sdkPath,"src", "boards", "include","boards");
 
       boardHeaderDirList.push(systemBoardHeaderDir);
-
-      const picoBoardHeaderDirs = 
-        await cmakeGetBoardHeaderDirs(workspaceFolder?.uri);
-
-    if(picoBoardHeaderDirs){
-      boardHeaderDirList.push(picoBoardHeaderDirs);
-    }
 
     interface IBoardFile{
       [key: string]: string;

--- a/src/utils/cmakeUtil.mts
+++ b/src/utils/cmakeUtil.mts
@@ -247,58 +247,6 @@ export async function configureCmakeNinja(folder: Uri): Promise<boolean> {
 }
 
 /**
- * Reads CMakeLists.txt file for PICO_BOARD_HEADER_DIRS
- *
- * @param folder The root folder of the workspace to configure.
- */
-export async function cmakeGetBoardHeaderDirs(
-  folder?: Uri,
-): Promise<string|null> {
-  if(folder === undefined)
-    {return null;}
-
-  // TODO: support for scaning for seperate locations of the CMakeLists.txt file in the project
-  const cmakeFilePath = join(folder.fsPath, "CMakeLists.txt");
-  const picoBoardRegex = /^set\(PICO_BOARD_HEADER_DIRS\s+([^)]+)\)$/m;
-  const cmakeCurrentListFileRegex = /^\${CMAKE_CURRENT_LIST_DIR}/m;
-
-  const settings = Settings.getInstance();
-  if (settings === undefined) {
-    Logger.error(LoggerSource.cmake, "Settings not initialized.");
-
-    return null;
-  }
-
-  try {
-    // check if CMakeLists.txt exists in the root folder
-    await workspace.fs.stat(folder.with({ path: cmakeFilePath }));
-
-    const cmakeListsFile = await readFile(cmakeFilePath, "utf8");
-    const matches = cmakeListsFile.match(picoBoardRegex);
-
-    if(matches === null) {
-      return null;
-    }
-
-    if(matches.length>1) {
-      let dir = matches[1].replace(cmakeCurrentListFileRegex,folder.fsPath);
-      dir = dir.replaceAll("\\", "/");
-
-      return dir;
-    }
-
-    return null;
-  } catch {
-    Logger.error(
-      LoggerSource.cmake,
-      "Settings not initialized."
-    );
-
-    return null;
-  }
-}
-
-/**
  * Changes the board in the CMakeLists.txt file.
  *
  * @param folder The root folder of the workspace to configure.


### PR DESCRIPTION
I added support to list board files listed from the variable PICO_BOARD_HEADER_DIRS from CMakeLists.txt.

This variable lets cmake include the proper board not only from the SDK Path.