### PR TITLE
Add support for looking into PICO_BOARD_HEADER_DIRS custom board header

### DIFF
--- a/src/commands/switchBoard.mts
+++ b/src/commands/switchBoard.mts
@@ -11,6 +11,7 @@ import {
   cmakeGetSelectedToolchainAndSDKVersions,
   cmakeUpdateBoard,
   cmakeUpdateSDK,
+  cmakeGetPicoVar,
 } from "../utils/cmakeUtil.mjs";
 import { join } from "path";
 import { compareLt } from "../utils/semverUtil.mjs";
@@ -32,6 +33,7 @@ export default class SwitchBoardCommand extends Command {
   public static async askBoard(sdkVersion: string):
       Promise<[string, boolean] | undefined> {
     const quickPickItems: string[] = ["pico", "pico_w"];
+    const workspaceFolder = workspace.workspaceFolders?.[0];
 
     if (!compareLt(sdkVersion, "2.0.0")) {
       quickPickItems.push("pico2");
@@ -42,10 +44,44 @@ export default class SwitchBoardCommand extends Command {
     }
 
     const sdkPath = buildSDKPath(sdkVersion);
+    const boardHeaderDirList = [];
 
-    readdirSync(join(sdkPath, "src", "boards", "include", "boards")).forEach(
-      file => {
-        quickPickItems.push(file.split(".")[0]);
+    if(workspaceFolder !== undefined) {
+      const ws = workspaceFolder.uri.fsPath;
+      const cMakeCachePath = join(ws, "build","CMakeCache.txt");
+
+      const picoBoardHeaderDirs = cmakeGetPicoVar(
+        cMakeCachePath,
+        "PICO_BOARD_HEADER_DIRS");
+
+      if(picoBoardHeaderDirs){
+        boardHeaderDirList.push(picoBoardHeaderDirs);
+      }
+    }
+
+    const systemBoardHeaderDir = 
+      join(sdkPath,"src", "boards", "include","boards");
+
+      boardHeaderDirList.push(systemBoardHeaderDir);
+
+    interface IBoardFile{
+      [key: string]: string;
+    };
+
+    const boardFiles:IBoardFile = {};
+
+    boardHeaderDirList.forEach(
+      path =>{
+        readdirSync(path).forEach(
+          file => {
+            const fullFilename = join(path, file);
+            if(fullFilename.endsWith(".h")) {
+              const boardName = file.split(".")[0];
+              boardFiles[boardName] = fullFilename;
+              quickPickItems.push(boardName);
+            }
+          }
+        )
       }
     );
 
@@ -58,11 +94,9 @@ export default class SwitchBoardCommand extends Command {
 
       return board;
     }
-
+    
     // Check that board doesn't have an RP2040 on it
-    const data = readFileSync(
-      join(sdkPath, "src", "boards", "include", "boards", `${board}.h`)
-    )
+    const data = readFileSync(boardFiles[board])
 
     if (data.includes("rp2040")) {
 

--- a/src/commands/switchBoard.mts
+++ b/src/commands/switchBoard.mts
@@ -38,7 +38,6 @@ export default class SwitchBoardCommand extends Command {
     if (!compareLt(sdkVersion, "2.0.0")) {
       quickPickItems.push("pico2");
     }
-
     if (!compareLt(sdkVersion, "2.1.0")) {
       quickPickItems.push("pico2_w");
     }
@@ -94,7 +93,6 @@ export default class SwitchBoardCommand extends Command {
 
       return board;
     }
-    
     // Check that board doesn't have an RP2040 on it
     const data = readFileSync(boardFiles[board])
 


### PR DESCRIPTION
Hi, i want to add support to reading custom headers boards by using the variable PICO_BOARD_HEADER_DIRS set at CMakeLists.txt (currently only one folder is being set at the variable). The reason is because there are people creating custom boards with custom flash chips.

Also our project is setting the project name using a CMake variable.

So any review is welcome to make this change more robust.

Thanks in advance!