### PR TITLE
Add modifiers to version bundles

### DIFF
--- a/data/0.18.0/versionBundles.json
+++ b/data/0.18.0/versionBundles.json
@@ -25,20 +25,35 @@
     "cmake": "v3.29.9",
     "picotool": "2.1.0",
     "toolchain": "13_3_Rel1",
-    "riscvToolchain": "RISCV_RPI_2_0_0_5"
+    "riscvToolchain": "RISCV_RPI_2_0_0_5",
+    "modifiers": {
+      "darwin_x64": {
+        "toolchain": "13_2_Rel1"
+      }
+    }
   },
   "2.1.1": {
     "ninja": "v1.12.1",
     "cmake": "v3.31.5",
     "picotool": "2.1.1",
     "toolchain": "14_2_Rel1",
-    "riscvToolchain": "RISCV_RPI_2_0_0_5"
+    "riscvToolchain": "RISCV_RPI_2_0_0_5",
+    "modifiers": {
+      "darwin_x64": {
+        "toolchain": "13_2_Rel1"
+      }
+    }
   },
   "2.2.0": {
     "ninja": "v1.12.1",
     "cmake": "v3.31.5",
     "picotool": "2.2.0-a4",
     "toolchain": "14_2_Rel1",
-    "riscvToolchain": "RISCV_ZCB_RPI_2_1_1_3"
+    "riscvToolchain": "RISCV_ZCB_RPI_2_1_1_3",
+    "modifiers": {
+      "darwin_x64": {
+        "toolchain": "13_2_Rel1"
+      }
+    }
   }
 }

--- a/src/utils/versionBundles.mts
+++ b/src/utils/versionBundles.mts
@@ -106,11 +106,21 @@ export default class VersionBundlesLoader {
       if (modifiers !== undefined) {
         const platformDouble = `${process.platform}_${process.arch}`;
         if (modifiers[platformDouble] !== undefined) {
-          chosenBundle.cmake =  modifiers[platformDouble]["cmake"] ?? chosenBundle.cmake
-          chosenBundle.ninja =  modifiers[platformDouble]["ninja"] ?? chosenBundle.ninja
-          chosenBundle.picotool =  modifiers[platformDouble]["picotool"] ?? chosenBundle.picotool
-          chosenBundle.toolchain =  modifiers[platformDouble]["toolchain"] ?? chosenBundle.toolchain
-          chosenBundle.riscvToolchain =  modifiers[platformDouble]["riscvToolchain"] ?? chosenBundle.riscvToolchain
+          chosenBundle.cmake =
+            modifiers[platformDouble]["cmake"] ?? chosenBundle.cmake
+
+          chosenBundle.ninja =
+            modifiers[platformDouble]["ninja"] ?? chosenBundle.ninja
+
+          chosenBundle.picotool =
+            modifiers[platformDouble]["picotool"] ?? chosenBundle.picotool
+
+          chosenBundle.toolchain =
+            modifiers[platformDouble]["toolchain"] ?? chosenBundle.toolchain
+
+          chosenBundle.riscvToolchain =
+            modifiers[platformDouble]["riscvToolchain"] ??
+              chosenBundle.riscvToolchain
         }
       }
     }


### PR DESCRIPTION
Allows modifying versions of tools for specific platforms, for example use 13.2.Rel1 toolchain instead of later toolchains on Intel MacOS, as later toolchains are linked against homebrew (https://forums.raspberrypi.com/viewtopic.php?t=380395)

Also removes unused Python section of version bundles, now that is a user setting