### PR TITLE
If settings contains an {invalid,unsupported} python version, properly clear it from settings

### DIFF
--- a/src/utils/pythonHelper.mts
+++ b/src/utils/pythonHelper.mts
@@ -65,7 +65,11 @@ export default async function findPython(): Promise<string | undefined> {
                   "python path or it is not supported:",
                 version
               );
-              // TODO: clear python path from settings
+              // if version is not supported, clear the path
+              await Settings.getInstance()?.updateGlobal(
+                SettingsKey.python3Path,
+                undefined
+              );
             }
           } catch (error) {
             Logger.warn(
@@ -75,6 +79,17 @@ export default async function findPython(): Promise<string | undefined> {
             );
           }
         }
+        // if path does not exist, clear it
+        else {
+          Logger.warn(
+            LoggerSource.pythonHelper,
+            "Python path set in user settings does not exist:",
+            pythonPath
+          );
+          await Settings.getInstance()?.updateGlobal(
+            SettingsKey.python3Path,
+            undefined
+          );
       }
 
       // Check python extension for any python environments with version >= 3.9


### PR DESCRIPTION
Somehow ended up with a scenario where the python path setting (`raspberry-pi-pico.python3Path`) was invalid on what I thought was a clean install of the extension.

Not sure why it wasn't getting cleared, but after looking through the code, I realized that it should be cleared here.

As a bonus, this might solve #142, too. Might have some other project-creation issues, but not sure what they are.
