### PR TITLE
Keep the first 3 numbers from git version

### DIFF
--- a/src/utils/gitUtil.mts
+++ b/src/utils/gitUtil.mts
@@ -26,7 +26,7 @@ export async function checkGitVersion(
   console.debug(
     `Git version check result: ${ret.stderr} stdout: ${ret.stdout}`
   );
-  const regex = /git version (\d+\.\d+(\.\d+)*)/;
+  const regex = /git version (\d+\.\d+\.\d+)/;
   const match = regex.exec(ret.stdout);
   if (match && match[1]) {
     const gitVersion = match[1];


### PR DESCRIPTION
The plugin fails because my laptop's custom git version `2.51.0.318` has four parts (this is probably because my org modified it), but the version checker expects a standard three-part format (e.g., MAJOR.MINOR.PATCH). This mismatch causes the checker to incorrectly flag my git installation as too old, preventing the plugin from running.

This PR fixes the issue by parsing only the first three numbers from the version string, making it compatible with the existing checker. An alternative would be to modify the version checker to support four-part versions.
