### PR TITLE
Fix run command for Zephyr projects on Windows

### DIFF
--- a/src/utils/projectGeneration/projectZephyr.mts
+++ b/src/utils/projectGeneration/projectZephyr.mts
@@ -374,6 +374,9 @@ async function generateVSCodeConfig(
         problemMatcher: [],
         dependsOrder: "sequence",
         dependsOn: "Compile Project",
+        windows: {
+          command: `"\${command:${extensionName}.${GET_PICOTOOL_PATH}}"`,
+        },
       },
     ],
   };


### PR DESCRIPTION
Requires these escapes to properly execute the command in the terminal