### PR TITLE
Don't add quotes around path returned by getEnvPath command

### DIFF
--- a/src/commands/getPaths.mts
+++ b/src/commands/getPaths.mts
@@ -92,7 +92,7 @@ export class GetEnvPathCommand extends CommandWithResult<string> {
     const env = await getPath();
     const pathValue = process.platform === "win32" ? env.Path : env.PATH;
 
-    return JSON.stringify(pathValue ?? "");
+    return pathValue ?? "";
   }
 }
 


### PR DESCRIPTION
These quotes were added in the 0.19.0 release, but I don't think they're necessary, and they break the CMake Tools Extension integration.

Fixes #236