### PR TITLE
Improve CMake Tools Kit forcing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,9 @@ This extension provides the following settings:
 
 ## CMake Tools Extension Integration
 
-For more complex projects, such as those with multiple executables or when the project name is defined as a variable, this extension can integrate with the CMake Tools extension to enhance CMake parsing. You can enable the CMake Tools Extension integration during project generation, using the checkbox at the bottom of the page. To enable it for an existing project, just re-import the project with the option selected. Alternatively, to manually enable it, adjust the following settings in your `settings.json`:
+For more complex projects, such as those with multiple executables or when the project name is defined as a variable, this extension can integrate with the CMake Tools extension to enhance CMake parsing. You can enable the CMake Tools Extension integration during project generation, using the checkbox at the bottom of the page. To enable it for an existing project, you should re-import the project with the option selected, which will update the relevant files.
 
-- `raspberry-pi-pico.cmakeAutoConfigure`: Set from `true` to `false`.
-- `raspberry-pi-pico.useCmakeTools`: Set from `false` to `true`.
-
-For optimal functionality, consider enabling:
-
-- `cmake.configureOnEdit`: true
-- `cmake.automaticReconfigure`: true
-- `cmake.configureOnOpen`: true
-
-When prompted, select the `Pico` kit in CMake Tools, and set your build and launch targets accordingly. Use CMake Tools for compilation, but continue using this extension for debugging, as CMake Tools debugging is not compatible with Pico.
+You should continue using this extension for running & debugging, and we recommend still using the buttons from this extension for compilation too, only using the CMake Tools extension for configuration. If prompted, select the `Pico` kit in CMake Tools.
 
 ## Additional Rust Prerequisites
 

--- a/scripts/pico_project.py
+++ b/scripts/pico_project.py
@@ -1104,11 +1104,17 @@ def generateProjectFiles(
         }},
         "debug": {{
             "statusBarVisibility": "hidden"
+        }},
+        "variant": {{
+            "statusBarVisibility": "{"compact" if useCmakeTools else "hidden"}",
+        }},
+        "buildTarget": {{
+            "statusBarVisibility": "{"visible" if useCmakeTools else "hidden"}",
         }}
     }},
     "cmake.configureOnEdit": {"true" if useCmakeTools else "false"},
     "cmake.automaticReconfigure": {"true" if useCmakeTools else "false"},
-    "cmake.configureOnOpen": {"true" if useCmakeTools else "false"},
+    "cmake.configureOnOpen": {"false"},
     "cmake.generator": "Ninja",
     "cmake.cmakePath": "{cmakePath.replace(user_home, "${userHome}") if use_home_var else cmakePath}",
     "C_Cpp.debugShortcut": false,

--- a/src/extension.mts
+++ b/src/extension.mts
@@ -1201,7 +1201,21 @@ export async function activate(context: ExtensionContext): Promise<void> {
     await cmakeSetupAutoConfigure(workspaceFolder, ui);
   } else if (settings.getBoolean(SettingsKey.useCmakeTools)) {
     // Ensure the Pico kit is selected
-    await cmakeToolsForcePicoKit();
+    const kitForced = await cmakeToolsForcePicoKit();
+    if (!kitForced) {
+      Logger.warn(LoggerSource.extension,
+        "Failed to force Pico kit in CMake Tools - attempting to do it later"
+      );
+
+      setTimeout(() => {
+        void cmakeToolsForcePicoKit().catch(error => {
+          Logger.error(LoggerSource.extension,
+            "Failed to force Pico kit in CMake Tools on second attempt",
+            unknownErrorToString(error)
+          );
+        });
+      }, 1000);
+    }
   } else {
     Logger.info(
       LoggerSource.extension,

--- a/src/utils/cmakeToolsUtil.mts
+++ b/src/utils/cmakeToolsUtil.mts
@@ -1,7 +1,7 @@
 import { commands, extensions } from "vscode";
 import Logger, { LoggerSource } from "../logger.mjs";
 
-export async function cmakeToolsForcePicoKit(): Promise<void> {
+export async function cmakeToolsActivate(): Promise<boolean> {
   // Check if the CMake Tools extension is installed and active
   let foundCmakeToolsExtension = false;
   for (let i = 0; i < 2; i++) {
@@ -44,15 +44,23 @@ export async function cmakeToolsForcePicoKit(): Promise<void> {
     await new Promise(resolve => setTimeout(resolve, 1000));
   }
 
-  if (!foundCmakeToolsExtension) {
+  return foundCmakeToolsExtension;
+}
+
+
+export async function cmakeToolsForcePicoKit(): Promise<boolean> {
+
+  if (!await cmakeToolsActivate()) {
     // Give up and return, as this function is non-essential
     Logger.warn(LoggerSource.cmake, "cmakeToolsExtension not available yet");
 
-    return;
+    return false;
   }
 
   const cmakeToolsKit = await commands.executeCommand("cmake.buildKit");
   if (cmakeToolsKit !== "Pico") {
     await commands.executeCommand("cmake.setKitByName", "Pico");
   }
+
+  return true;
 }


### PR DESCRIPTION
Use the `setKitByName` command to set the Pico kit directly, rather than popping it up for the user to click it in the dialogue