### PR TITLE
Add pre-release action

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -1,0 +1,21 @@
+name: Pre-release
+
+on: workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRE_RELEASE_PAT }}
+      - name: Increment version
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          npm version patch -m "Pre-release %s"
+          git push --follow-tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
             debug-raspberry-pi-pico-*.vsix
             raspberry-pi-pico-*.vsix
             ovsx-raspberry-pi-pico-*.vsix
+
+      # Test PATs
       - name: Test PAT
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
         env:
@@ -72,21 +74,38 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
         run: |
           npx ovsx verify-pat -p ${{ secrets.OPEN_VSX_PAT }}
+
+      # Pre-release
+      - name: Add Pre-release Notes
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/') && contains(github.event.head_commit.message, 'Pre-release')
+        with:
+          prerelease: true
+          generate_release_notes: true
+          body: "> **Note: This is a pre-release, so may not be stable**"
+          files: |
+            debug-raspberry-pi-pico-*.vsix
+            raspberry-pi-pico-*.vsix
+            ovsx-raspberry-pi-pico-*.vsix
+
+      # Release
       - name: Add Release Asset
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && !contains(github.event.head_commit.message, 'Pre-release')
         with:
           files: |
             debug-raspberry-pi-pico-*.vsix
             raspberry-pi-pico-*.vsix
             ovsx-raspberry-pi-pico-*.vsix
+
+      # Publishing
       - name: Publish Extension
         if: startsWith(github.ref, 'refs/tags/')
         env:
           VSCE_PAT: ${{ secrets.VSCODE_MARKETPLACE_PAT }}
         run: |
-          vsce publish -i raspberry-pi-pico-*.vsix
+          vsce publish -i ${{ contains(github.event.head_commit.message, 'Pre-release') && 'debug-raspberry-pi-pico-*.vsix --pre-release' || 'raspberry-pi-pico-*.vsix' }}
       - name: Publish Extension to OVSX
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          npx ovsx publish ovsx-raspberry-pi-pico-*.vsix -p ${{ secrets.OPEN_VSX_PAT }}
+          npx ovsx publish ovsx-raspberry-pi-pico-*.vsix -p ${{ secrets.OPEN_VSX_PAT }} ${{ contains(github.event.head_commit.message, 'Pre-release') && '--pre-release' || '' }}


### PR DESCRIPTION
Add a workflow to do pre-releases (using patch version, as VS Code only supports x.x.x versions)

Pre-releases can now be done by dispatching the Pre-release workflow, which will do a patch release and publish the debug version of the extension

Main releases still need to be done as before, and should be limited to major/minor versions to avoid confusion (ie anything that isn't x.x.0 is a pre-release)