### PR TITLE
Fix: Local Zephyr snippets not detected without SNIPPET_ROOT

### DIFF
--- a/src/utils/projectGeneration/projectZephyr.mts
+++ b/src/utils/projectGeneration/projectZephyr.mts
@@ -305,6 +305,7 @@ async function generateVSCodeConfig(
   // If console is USB, use the local snippet
   if (data.console === "USB") {
     westArgs.push("-S", "usb_serial_port");
+    westArgs.push("-DSNIPPET_ROOT=${workspaceFolder}");
   }
 
   westArgs.push(


### PR DESCRIPTION
### Description

This PR fixes an issue where local Zephyr snippets inside:

`<workspace>/snippets/`

were not detected during build.

When selecting USB console, the extension added:

`-S usb_serial_port`

but did not set `SNIPPET_ROOT`.

As a result, Zephyr only searched in the zephyr repository:

`Snippet roots for application:
    <zephyr-main>`

and failed with:

`snippets: error: snippets not found: usb_serial_port`

### Fix

Add:

`-DSNIPPET_ROOT=${workspaceFolder}`

when pushing the USB snippet argument:

`if (data.console === "USB") {
  westArgs.push("-S", "usb_serial_port");
  westArgs.push("-DSNIPPET_ROOT=${workspaceFolder}");
}`

This ensures local snippets are correctly discovered.

### Tested On

- Windows
- rpi_pico2/rp2350a/m33
- Local snippet in <workspace>/snippets/usb_serial_port

Build succeeds after fix.