### PR TITLE
Refactor Pico project activation around project variants

### DIFF
--- a/src/commands/getPaths.mts
+++ b/src/commands/getPaths.mts
@@ -1,12 +1,6 @@
 import { CommandWithResult } from "./command.mjs";
-import { commands, Uri, window, workspace } from "vscode";
-import {
-  getPythonPath,
-  getPath,
-  cmakeGetSelectedToolchainAndSDKVersions,
-  cmakeGetPicoVar,
-} from "../utils/cmakeUtil.mjs";
-import { join } from "path";
+import { Uri, window, workspace } from "vscode";
+import { getPythonPath, getPath } from "../utils/cmakeUtil.mjs";
 import { join as joinPosix } from "path/posix";
 import {
   buildOpenOCDPath,
@@ -18,15 +12,11 @@ import {
   downloadAndInstallOpenOCD,
   downloadAndInstallPicotool,
 } from "../utils/download.mjs";
-import Settings, { SettingsKey } from "../settings.mjs";
+import type Settings from "../settings.mjs";
 import which from "which";
 import { execSync } from "child_process";
 import { getPicotoolReleases } from "../utils/githubREST.mjs";
-import State from "../state.mjs";
-import VersionBundlesLoader from "../utils/versionBundles.mjs";
-import { getSupportedToolchains } from "../utils/toolchainUtil.mjs";
 import Logger from "../logger.mjs";
-import { rustProjectGetSelectedChip } from "../utils/rustUtil.mjs";
 import { OPENOCD_VERSION } from "../utils/sharedConstants.mjs";
 import {
   GET_CHIP,
@@ -46,16 +36,17 @@ import {
   GET_ZEPHYR_WORKSPACE_PATH,
 } from "./cmdIds.mjs";
 import {
-  getBoardFromZephyrProject,
   getZephyrSDKVersion,
 } from "../utils/setupZephyr.mjs";
-import {
-  ZEPHYR_PICO,
-  ZEPHYR_PICO2,
-  ZEPHYR_PICO2_W,
-  ZEPHYR_PICO_W,
-} from "../models/zephyrBoards.mjs";
 import { ensureGit } from "../utils/gitUtil.mjs";
+import {
+  getActiveProjectChip,
+  getActiveProjectSdkVersion,
+  getActiveProjectTarget,
+  getActiveProjectToolchainVersion,
+  getActiveProjectVariant,
+  toolchainTriple,
+} from "../projectVariants/selectionHelpers.mjs";
 
 export class GetPythonPathCommand extends CommandWithResult<string> {
   constructor() {
@@ -110,59 +101,20 @@ export class GetGDBPathCommand extends CommandWithResult<string> {
     }
 
     const workspaceFolder = workspace.workspaceFolders?.[0];
-    const isRustProject = State.getInstance().isRustProject;
-    let toolchainVersion = "";
-
-    if (isRustProject) {
-      // check if latest toolchain is installed
-      const vbl = new VersionBundlesLoader(this._extensionUri);
-      const latestVb = await vbl.getLatest();
-
-      if (!latestVb) {
-        void window.showErrorMessage("No version bundles found.");
-
-        return "";
-      }
-
-      const supportedToolchains = await getSupportedToolchains(
-        this._extensionUri
+    const toolchainVersion = await getActiveProjectToolchainVersion(
+      workspaceFolder,
+      this._extensionUri
+    );
+    if (toolchainVersion === undefined) {
+      void window.showErrorMessage(
+        "No supported toolchain found for this project."
       );
-      const latestSupportedToolchain = supportedToolchains.find(
-        t => t.version === latestVb[1].toolchain
-      );
-      if (!latestSupportedToolchain) {
-        void window.showErrorMessage(
-          "No supported toolchain found for the latest version."
-        );
 
-        return "";
-      }
-
-      const useRISCV = rustProjectGetSelectedChip(
-        workspaceFolder.uri.fsPath
-      )?.includes("riscv");
-
-      toolchainVersion = useRISCV
-        ? latestVb[1].riscvToolchain
-        : latestVb[1].toolchain;
-    } else {
-      const selectedToolchainAndSDKVersions =
-        await cmakeGetSelectedToolchainAndSDKVersions(workspaceFolder.uri);
-      if (selectedToolchainAndSDKVersions === null) {
-        return "";
-      }
-
-      toolchainVersion = selectedToolchainAndSDKVersions[1];
+      return "";
     }
 
-    let triple = "arm-none-eabi";
-    if (toolchainVersion.includes("RISCV")) {
-      if (toolchainVersion.includes("COREV")) {
-        triple = "riscv32-corev-elf";
-      } else {
-        triple = "riscv32-unknown-elf";
-      }
-    } else if (process.platform === "linux") {
+    const triple = toolchainTriple(toolchainVersion);
+    if (triple === "arm-none-eabi" && process.platform === "linux") {
       // Arm toolchains have incorrect libncurses versions on Linux (specifically RPiOS)
       const gdbPath = await which("gdb", { nothrow: true });
       if (gdbPath !== null) {
@@ -207,22 +159,13 @@ export class GetCompilerPathCommand extends CommandWithResult<string> {
     }
 
     const workspaceFolder = workspace.workspaceFolders?.[0];
-
-    const selectedToolchainAndSDKVersions =
-      await cmakeGetSelectedToolchainAndSDKVersions(workspaceFolder.uri);
-    if (selectedToolchainAndSDKVersions === null) {
+    const toolchainVersion = await getActiveProjectToolchainVersion(
+      workspaceFolder
+    );
+    if (toolchainVersion === undefined) {
       return "";
     }
-    const toolchainVersion = selectedToolchainAndSDKVersions[1];
-
-    let triple = "arm-none-eabi";
-    if (toolchainVersion.includes("RISCV")) {
-      if (toolchainVersion.includes("COREV")) {
-        triple = "riscv32-corev-elf";
-      } else {
-        triple = "riscv32-unknown-elf";
-      }
-    }
+    const triple = toolchainTriple(toolchainVersion);
 
     return joinPosix(
       buildToolchainPath(toolchainVersion),
@@ -246,22 +189,13 @@ export class GetCxxCompilerPathCommand extends CommandWithResult<string> {
     }
 
     const workspaceFolder = workspace.workspaceFolders?.[0];
-
-    const selectedToolchainAndSDKVersions =
-      await cmakeGetSelectedToolchainAndSDKVersions(workspaceFolder.uri);
-    if (selectedToolchainAndSDKVersions === null) {
+    const toolchainVersion = await getActiveProjectToolchainVersion(
+      workspaceFolder
+    );
+    if (toolchainVersion === undefined) {
       return "";
     }
-    const toolchainVersion = selectedToolchainAndSDKVersions[1];
-
-    let triple = "arm-none-eabi";
-    if (toolchainVersion.includes("RISCV")) {
-      if (toolchainVersion.includes("COREV")) {
-        triple = "riscv32-corev-elf";
-      } else {
-        triple = "riscv32-unknown-elf";
-      }
-    }
+    const triple = toolchainTriple(toolchainVersion);
 
     return joinPosix(
       buildToolchainPath(toolchainVersion),
@@ -287,88 +221,14 @@ export class GetChipCommand extends CommandWithResult<string> {
     }
 
     const workspaceFolder = workspace.workspaceFolders?.[0];
-    const isRustProject = State.getInstance().isRustProject;
-    const isZephyrProject = State.getInstance().isZephyrProject;
+    const chip = await getActiveProjectChip(workspaceFolder);
+    if (chip === undefined) {
+      this._logger.error("Failed to read active project chip");
 
-    if (isZephyrProject) {
-      const board = await getBoardFromZephyrProject(
-        join(workspaceFolder.uri.fsPath, ".vscode", "tasks.json")
-      );
-
-      if (board === undefined) {
-        this._logger.error("Failed to read Zephyr board from tasks.json");
-
-        return "";
-      }
-
-      switch (board) {
-        case ZEPHYR_PICO:
-        case ZEPHYR_PICO_W:
-          return "rp2040";
-        case ZEPHYR_PICO2:
-        case ZEPHYR_PICO2_W:
-          return "rp2350";
-        default:
-          this._logger.error(`Unsupported Zephyr board: ${board}`);
-          void window.showErrorMessage(
-            `Unsupported Zephyr board: ${board}. ` +
-              `Supported boards are: ${ZEPHYR_PICO}, ${ZEPHYR_PICO_W}, ` +
-              `${ZEPHYR_PICO2}, ${ZEPHYR_PICO2_W}`
-          );
-
-          return "rp2040";
-      }
-    }
-
-    if (isRustProject) {
-      // read .pico-rs
-      const chip = rustProjectGetSelectedChip(workspaceFolder.uri.fsPath);
-      if (chip === null) {
-        this._logger.error("Failed to read .pico-rs");
-
-        return "";
-      }
-
-      switch (chip) {
-        case "rp2040":
-          return "rp2040";
-        case "rp2350":
-        case "rp2350-riscv":
-          return "rp235x";
-        default:
-          return "rp2040";
-      }
-    }
-
-    const settings = Settings.getInstance();
-    let buildDir = join(workspaceFolder.uri.fsPath, "build");
-    if (
-      settings !== undefined &&
-      settings.getBoolean(SettingsKey.useCmakeTools)
-    ) {
-      // Compiling with CMake Tools
-      const cmakeBuildDir: string = await commands.executeCommand(
-        "cmake.buildDirectory"
-      );
-
-      if (cmakeBuildDir) {
-        buildDir = cmakeBuildDir;
-      }
-    }
-
-    const platform = cmakeGetPicoVar(
-      join(buildDir, "CMakeCache.txt"),
-      "PICO_PLATFORM"
-    );
-    if (platform === null) {
       return "rp2040";
     }
 
-    if (platform === "rp2350-arm-s" || platform === "rp2350-riscv") {
-      return "rp2350";
-    } else {
-      return "rp2040";
-    }
+    return chip;
   }
 }
 
@@ -399,66 +259,8 @@ export class GetTargetCommand extends CommandWithResult<string> {
     }
 
     const workspaceFolder = workspace.workspaceFolders?.[0];
-    const isRustProject = State.getInstance().isRustProject;
-    const isZephyrProject = State.getInstance().isZephyrProject;
 
-    if (isZephyrProject) {
-      const board = await getBoardFromZephyrProject(
-        join(workspaceFolder.uri.fsPath, ".vscode", "tasks.json")
-      );
-
-      if (board === undefined) {
-        return "rp2040";
-      }
-
-      switch (board) {
-        case ZEPHYR_PICO:
-        case ZEPHYR_PICO_W:
-          return "rp2040";
-        case ZEPHYR_PICO2:
-        case ZEPHYR_PICO2_W:
-          return "rp2350";
-        default:
-          return "rp2040";
-      }
-    }
-    if (isRustProject) {
-      const chip = rustProjectGetSelectedChip(workspaceFolder.uri.fsPath);
-
-      return chip === null ? "rp2040" : chip.toLowerCase();
-    }
-
-    const settings = Settings.getInstance();
-    let buildDir = join(workspaceFolder.uri.fsPath, "build");
-    if (
-      settings !== undefined &&
-      settings.getBoolean(SettingsKey.useCmakeTools)
-    ) {
-      // Compiling with CMake Tools
-      const cmakeBuildDir: string = await commands.executeCommand(
-        "cmake.buildDirectory"
-      );
-
-      if (cmakeBuildDir) {
-        buildDir = cmakeBuildDir;
-      }
-    }
-
-    const platform = cmakeGetPicoVar(
-      join(buildDir, "CMakeCache.txt"),
-      "PICO_PLATFORM"
-    );
-    if (platform === null) {
-      return "rp2040";
-    }
-
-    if (platform === "rp2350-arm-s") {
-      return "rp2350";
-    } else if (platform === "rp2350-riscv") {
-      return "rp2350-riscv";
-    } else {
-      return "rp2040";
-    }
+    return (await getActiveProjectTarget(workspaceFolder)) ?? "rp2040";
   }
 }
 
@@ -557,26 +359,26 @@ export class GetSVDPathCommand extends CommandWithResult<string | undefined> {
       return "";
     }
 
-    const isRustProject = State.getInstance().isRustProject;
-    if (!isRustProject) {
+    const workspaceFolder = workspace.workspaceFolders[0];
+    const variant = await getActiveProjectVariant(workspaceFolder);
+    if (variant?.id !== "rust") {
       return;
     }
 
-    const vs = new VersionBundlesLoader(this._extensionUri);
-    const latestSDK = await vs.getLatestSDK();
+    const latestSDK = await getActiveProjectSdkVersion(
+      workspaceFolder,
+      this._extensionUri
+    );
     if (!latestSDK) {
       return;
     }
 
-    const chip = rustProjectGetSelectedChip(
-      workspace.workspaceFolders[0].uri.fsPath
-    );
-
-    if (!chip) {
+    const target = await getActiveProjectTarget(workspaceFolder);
+    if (target === undefined) {
       return;
     }
 
-    const theChip = chip === "rp2350-riscv" ? "rp2350" : chip;
+    const theChip = target === "rp2350-riscv" ? "rp2350" : target;
 
     return joinPosix(
       buildSDKPath(latestSDK),

--- a/src/commands/getPaths.mts
+++ b/src/commands/getPaths.mts
@@ -1,5 +1,5 @@
 import { CommandWithResult } from "./command.mjs";
-import { Uri, window, workspace } from "vscode";
+import { Uri, window, workspace, type WorkspaceFolder } from "vscode";
 import { getPythonPath, getPath } from "../utils/cmakeUtil.mjs";
 import { join as joinPosix } from "path/posix";
 import {
@@ -35,13 +35,19 @@ import {
   GET_ZEPHYR_SDK_PATH,
   GET_ZEPHYR_WORKSPACE_PATH,
 } from "./cmdIds.mjs";
-import {
-  getZephyrSDKVersion,
-} from "../utils/setupZephyr.mjs";
+import { getZephyrSDKVersion } from "../utils/setupZephyr.mjs";
 import { ensureGit } from "../utils/gitUtil.mjs";
 import {
+  ZEPHYR_PICO,
+  ZEPHYR_PICO2,
+  ZEPHYR_PICO2_W,
+  ZEPHYR_PICO_W,
+} from "../models/zephyrBoards.mjs";
+import {
   getActiveProjectChip,
+  getActiveProjectSelections,
   getActiveProjectSdkVersion,
+  getActiveProjectSupportedToolchain,
   getActiveProjectTarget,
   getActiveProjectToolchainVersion,
   getActiveProjectVariant,
@@ -101,14 +107,27 @@ export class GetGDBPathCommand extends CommandWithResult<string> {
     }
 
     const workspaceFolder = workspace.workspaceFolders?.[0];
-    const toolchainVersion = await getActiveProjectToolchainVersion(
-      workspaceFolder,
-      this._extensionUri
-    );
+    const variant = await getActiveProjectVariant(workspaceFolder);
+    const toolchainVersion =
+      variant?.id === "rust"
+        ? await getActiveProjectSupportedToolchain(
+            workspaceFolder,
+            this._extensionUri
+          )
+        : await getActiveProjectToolchainVersion(
+            workspaceFolder,
+            this._extensionUri
+          );
     if (toolchainVersion === undefined) {
-      void window.showErrorMessage(
-        "No supported toolchain found for this project."
-      );
+      if (variant?.id === "rust") {
+        void window.showErrorMessage(
+          "No supported toolchain found for the latest version."
+        );
+      } else if (variant?.id !== "zephyr") {
+        void window.showErrorMessage(
+          "No supported toolchain found for this project."
+        );
+      }
 
       return "";
     }
@@ -223,12 +242,31 @@ export class GetChipCommand extends CommandWithResult<string> {
     const workspaceFolder = workspace.workspaceFolders?.[0];
     const chip = await getActiveProjectChip(workspaceFolder);
     if (chip === undefined) {
-      this._logger.error("Failed to read active project chip");
+      await this.showProjectChipError(workspaceFolder);
 
       return "rp2040";
     }
 
     return chip;
+  }
+
+  private async showProjectChipError(
+    workspaceFolder: WorkspaceFolder
+  ): Promise<void> {
+    const variant = await getActiveProjectVariant(workspaceFolder);
+    const selections = await getActiveProjectSelections(workspaceFolder);
+    if (variant?.id === "zephyr" && selections?.boardId !== undefined) {
+      this._logger.error(`Unsupported Zephyr board: ${selections.boardId}`);
+      void window.showErrorMessage(
+        `Unsupported Zephyr board: ${selections.boardId}. ` +
+          `Supported boards are: ${ZEPHYR_PICO}, ${ZEPHYR_PICO_W}, ` +
+          `${ZEPHYR_PICO2}, ${ZEPHYR_PICO2_W}`
+      );
+
+      return;
+    }
+
+    this._logger.error("Failed to read active project chip");
   }
 }
 

--- a/src/extension.mts
+++ b/src/extension.mts
@@ -4,6 +4,7 @@ import {
   window,
   type WebviewPanel,
   commands,
+  type WorkspaceFolder,
 } from "vscode";
 import {
   extensionName,
@@ -71,6 +72,16 @@ import OpenUninstallerCommand from "./commands/openUninstaller.mjs";
 import { CleanZephyrCommand } from "./commands/cleanZephyr.mjs";
 import { createProjectVariantRegistry } from "./projectVariants/index.mjs";
 import { setProjectContext } from "./projectVariants/common.mjs";
+import type {
+  PicoProjectVariant,
+  ProjectDetectionResult,
+  ProjectSelections,
+} from "./projectVariants/index.mjs";
+
+type UnsupportedProjectDetection = Extract<
+  ProjectDetectionResult,
+  { kind: "unsupported" }
+>;
 
 export async function activate(context: ExtensionContext): Promise<void> {
   Logger.info(LoggerSource.extension, "Extension activation triggered");
@@ -210,80 +221,150 @@ export async function activate(context: ExtensionContext): Promise<void> {
     )
   );
 
+  await activateWorkspaceProject(context, settings, ui);
+}
+
+async function activateWorkspaceProject(
+  context: ExtensionContext,
+  settings: Settings,
+  ui: UI
+): Promise<void> {
   const workspaceFolder = workspace.workspaceFolders?.[0];
   if (workspaceFolder === undefined) {
     Logger.warn(LoggerSource.extension, "No workspace folder found.");
-    await setProjectContext({
-      isPicoProject: false,
-      isRustProject: false,
-      isZephyrProject: false,
-    });
+    await resetProjectContext();
 
     return;
   }
 
-  const registry = createProjectVariantRegistry();
-  const detection = await registry.detect(workspaceFolder);
+  const detection = await detectPicoProject(workspaceFolder);
   if (detection.kind === "unsupported") {
-    Logger.warn(LoggerSource.extension, detection.reason);
-    await setProjectContext({
-      isPicoProject: false,
-      isRustProject: false,
-      isZephyrProject: false,
-    });
-    State.getInstance().isRustProject = false;
-    State.getInstance().isZephyrProject = false;
-
-    if (detection.offerImport) {
-      const wantToImport = await window.showInformationMessage(
-        "Do you want to import this project as Raspberry Pi Pico project?",
-        "Yes",
-        "No"
-      );
-      if (wantToImport === "Yes") {
-        void commands.executeCommand(
-          `${extensionName}.${IMPORT_PROJECT}`,
-          workspaceFolder.uri
-        );
-      }
-    }
+    await handleUnsupportedProject(detection, workspaceFolder);
 
     return;
   }
 
-  const variant = registry.get(detection.variant);
-  await setProjectContext(variant.context);
-  State.getInstance().isRustProject = variant.context.isRustProject;
-  State.getInstance().isZephyrProject = variant.context.isZephyrProject;
+  const variant = createProjectVariantRegistry().get(detection.variant);
+  await setActiveProjectVariant(variant);
 
-  const selections = await variant.readSelections(workspaceFolder);
+  const selections = await readProjectSelections(variant, workspaceFolder);
   if (selections === null) {
     return;
   }
 
-  const dependenciesReady = await variant.ensureDependencies({
+  const dependenciesReady = await ensureProjectDependencies(
+    variant,
+    context,
+    settings,
+    workspaceFolder,
+    selections
+  );
+  if (!dependenciesReady) {
+    return;
+  }
+
+  await updateProjectUi(variant, ui, selections);
+  await finishProjectActivation(
+    variant,
+    context,
+    settings,
+    workspaceFolder,
+    ui,
+    selections
+  );
+}
+
+async function detectPicoProject(
+  workspaceFolder: WorkspaceFolder
+): Promise<ProjectDetectionResult> {
+  return createProjectVariantRegistry().detect(workspaceFolder);
+}
+
+async function handleUnsupportedProject(
+  detection: UnsupportedProjectDetection,
+  workspaceFolder: WorkspaceFolder
+): Promise<void> {
+  Logger.warn(LoggerSource.extension, detection.reason);
+  await resetProjectContext();
+
+  if (detection.kind === "unsupported" && detection.offerImport) {
+    const wantToImport = await window.showInformationMessage(
+      "Do you want to import this project as Raspberry Pi Pico project?",
+      "Yes",
+      "No"
+    );
+    if (wantToImport === "Yes") {
+      void commands.executeCommand(
+        `${extensionName}.${IMPORT_PROJECT}`,
+        workspaceFolder.uri
+      );
+    }
+  }
+}
+
+async function resetProjectContext(): Promise<void> {
+  await setProjectContext({
+    isPicoProject: false,
+    isRustProject: false,
+    isZephyrProject: false,
+  });
+  State.getInstance().isRustProject = false;
+  State.getInstance().isZephyrProject = false;
+}
+
+async function setActiveProjectVariant(
+  variant: PicoProjectVariant
+): Promise<void> {
+  await setProjectContext(variant.context);
+  State.getInstance().isRustProject = variant.context.isRustProject;
+  State.getInstance().isZephyrProject = variant.context.isZephyrProject;
+}
+
+async function readProjectSelections(
+  variant: PicoProjectVariant,
+  workspaceFolder: WorkspaceFolder
+): Promise<ProjectSelections | null> {
+  return variant.readSelections(workspaceFolder);
+}
+
+async function ensureProjectDependencies(
+  variant: PicoProjectVariant,
+  context: ExtensionContext,
+  settings: Settings,
+  workspaceFolder: WorkspaceFolder,
+  selections: ProjectSelections
+): Promise<boolean> {
+  return variant.ensureDependencies({
     context,
     folder: workspaceFolder,
     selections,
     settings,
   });
-  if (!dependenciesReady) {
-    return;
-  }
+}
 
+async function updateProjectUi(
+  variant: PicoProjectVariant,
+  ui: UI,
+  selections: ProjectSelections
+): Promise<void> {
   await variant.updateUi({ ui, selections });
+}
 
-  const activated =
-    (await variant.afterActivation?.({
-      context,
-      folder: workspaceFolder,
-      selections,
-      settings,
-      ui,
-    })) ?? true;
-  if (!activated) {
-    return;
-  }
+async function finishProjectActivation(
+  variant: PicoProjectVariant,
+  context: ExtensionContext,
+  settings: Settings,
+  workspaceFolder: WorkspaceFolder,
+  ui: UI,
+  selections: ProjectSelections
+): Promise<void> {
+  await variant.afterActivation?.({
+    context,
+    folder: workspaceFolder,
+    selections,
+    settings,
+    ui,
+  });
 }
 
 export function deactivate(): void {

--- a/src/extension.mts
+++ b/src/extension.mts
@@ -70,7 +70,7 @@ import { getWebviewOptions } from "./webview/sharedFunctions.mjs";
 import { UninstallerPanel } from "./webview/uninstallerPanel.mjs";
 import OpenUninstallerCommand from "./commands/openUninstaller.mjs";
 import { CleanZephyrCommand } from "./commands/cleanZephyr.mjs";
-import { createProjectVariantRegistry } from "./projectVariants/index.mjs";
+import { getProjectVariantRegistry } from "./projectVariants/index.mjs";
 import { setProjectContext } from "./projectVariants/common.mjs";
 import type {
   PicoProjectVariant,
@@ -244,7 +244,7 @@ async function activateWorkspaceProject(
     return;
   }
 
-  const variant = createProjectVariantRegistry().get(detection.variant);
+  const variant = getProjectVariantRegistry().get(detection.variant);
   await setActiveProjectVariant(variant);
 
   const selections = await readProjectSelections(variant, workspaceFolder);
@@ -281,7 +281,7 @@ async function activateWorkspaceProject(
 async function detectPicoProject(
   workspaceFolder: WorkspaceFolder
 ): Promise<ProjectDetectionResult> {
-  return createProjectVariantRegistry().detect(workspaceFolder);
+  return getProjectVariantRegistry().detect(workspaceFolder);
 }
 
 async function handleUnsupportedProject(

--- a/src/extension.mts
+++ b/src/extension.mts
@@ -249,6 +249,8 @@ async function activateWorkspaceProject(
 
   const selections = await readProjectSelections(variant, workspaceFolder);
   if (selections === null) {
+    await resetProjectContext();
+
     return;
   }
 
@@ -260,6 +262,8 @@ async function activateWorkspaceProject(
     selections
   );
   if (!dependenciesReady) {
+    await resetProjectContext();
+
     return;
   }
 

--- a/src/extension.mts
+++ b/src/extension.mts
@@ -4,10 +4,6 @@ import {
   window,
   type WebviewPanel,
   commands,
-  ProgressLocation,
-  Uri,
-  FileSystemError,
-  type WorkspaceFolder,
 } from "vscode";
 import {
   extensionName,
@@ -17,23 +13,9 @@ import {
 } from "./commands/command.mjs";
 import NewProjectCommand from "./commands/newProject.mjs";
 import Logger, { LoggerSource } from "./logger.mjs";
-import {
-  CMAKE_DO_NOT_EDIT_HEADER_PREFIX,
-  CMAKE_DO_NOT_EDIT_HEADER_PREFIX_OLD,
-  cmakeGetPicoVar,
-  cmakeGetSelectedBoard,
-  cmakeGetSelectedToolchainAndSDKVersions,
-  configureCmakeNinja,
-} from "./utils/cmakeUtil.mjs";
-import Settings, {
-  SettingsKey,
-  type PackageJSON,
-  HOME_VAR,
-} from "./settings.mjs";
+import Settings, { type PackageJSON } from "./settings.mjs";
 import UI from "./ui.mjs";
 import SwitchSDKCommand from "./commands/switchSDK.mjs";
-import { existsSync, readFileSync } from "fs";
-import { basename, join } from "path";
 import CompileProjectCommand from "./commands/compileProject.mjs";
 import RunProjectCommand from "./commands/runProject.mjs";
 import LaunchTargetPathCommand, {
@@ -58,16 +40,6 @@ import {
   GetZephyrSDKPathCommand,
   GetGitPathCommand,
 } from "./commands/getPaths.mjs";
-import {
-  downloadAndInstallCmake,
-  downloadAndInstallNinja,
-  downloadAndInstallSDK,
-  downloadAndInstallToolchain,
-  downloadAndInstallTools,
-  downloadAndInstallPicotool,
-  downloadAndInstallOpenOCD,
-} from "./utils/download.mjs";
-import { getSupportedToolchains } from "./utils/toolchainUtil.mjs";
 import { NewProjectPanel } from "./webview/newProjectPanel.mjs";
 import GithubApiCache from "./utils/githubApiCache.mjs";
 import ClearGithubApiCacheCommand from "./commands/clearGithubApiCache.mjs";
@@ -81,7 +53,6 @@ import ConfigureCmakeCommand, {
   SwitchBuildTypeCommand,
 } from "./commands/configureCmake.mjs";
 import ImportProjectCommand from "./commands/importProject.mjs";
-import { homedir } from "os";
 import NewExampleProjectCommand from "./commands/newExampleProject.mjs";
 import SwitchBoardCommand from "./commands/switchBoard.mjs";
 import UninstallPicoSDKCommand from "./commands/uninstallPicoSDK.mjs";
@@ -89,44 +60,17 @@ import UpdateOpenOCDCommand from "./commands/updateOpenOCD.mjs";
 import FlashProjectSWDCommand from "./commands/flashProjectSwd.mjs";
 // eslint-disable-next-line max-len
 import { NewMicroPythonProjectPanel } from "./webview/newMicroPythonProjectPanel.mjs";
-import type { Progress as GotProgress } from "got";
-import findPython, { showPythonNotFoundError } from "./utils/pythonHelper.mjs";
-import {
-  downloadAndInstallRust,
-  installLatestRustRequirements,
-  rustProjectGetSelectedChip,
-} from "./utils/rustUtil.mjs";
 import State from "./state.mjs";
-import { cmakeToolsForcePicoKit } from "./utils/cmakeToolsUtil.mjs";
 import { NewRustProjectPanel } from "./webview/newRustProjectPanel.mjs";
-import {
-  CMAKELISTS_ZEPHYR_REGEX,
-  OPENOCD_VERSION,
-  SDK_REPOSITORY_URL,
-} from "./utils/sharedConstants.mjs";
-import VersionBundlesLoader from "./utils/versionBundles.mjs";
-import { unknownErrorToString } from "./utils/errorHelper.mjs";
-import {
-  getBoardFromZephyrProject,
-  getZephyrVersion,
-  setupZephyr,
-  updateZephyrCompilerPath,
-  updateZephyrVersion,
-  zephyrVerifyCMakeCache,
-} from "./utils/setupZephyr.mjs";
 import { IMPORT_PROJECT } from "./commands/cmdIds.mjs";
-import {
-  ZEPHYR_PICO,
-  ZEPHYR_PICO2,
-  ZEPHYR_PICO2_W,
-  ZEPHYR_PICO_W,
-} from "./models/zephyrBoards.mjs";
 import { NewZephyrProjectPanel } from "./webview/newZephyrProjectPanel.mjs";
 import LastUsedDepsStore from "./utils/lastUsedDeps.mjs";
 import { getWebviewOptions } from "./webview/sharedFunctions.mjs";
 import { UninstallerPanel } from "./webview/uninstallerPanel.mjs";
 import OpenUninstallerCommand from "./commands/openUninstaller.mjs";
 import { CleanZephyrCommand } from "./commands/cleanZephyr.mjs";
+import { createProjectVariantRegistry } from "./projectVariants/index.mjs";
+import { setProjectContext } from "./projectVariants/common.mjs";
 
 export async function activate(context: ExtensionContext): Promise<void> {
   Logger.info(LoggerSource.extension, "Extension activation triggered");
@@ -267,398 +211,30 @@ export async function activate(context: ExtensionContext): Promise<void> {
   );
 
   const workspaceFolder = workspace.workspaceFolders?.[0];
-  const isRustProject = workspaceFolder
-    ? existsSync(join(workspaceFolder.uri.fsPath, ".pico-rs"))
-    : false;
-
-  // check if there is a workspace folder
   if (workspaceFolder === undefined) {
-    // finish activation
     Logger.warn(LoggerSource.extension, "No workspace folder found.");
-    await commands.executeCommand(
-      "setContext",
-      ContextKeys.isPicoProject,
-      false
-    );
+    await setProjectContext({
+      isPicoProject: false,
+      isRustProject: false,
+      isZephyrProject: false,
+    });
 
     return;
   }
 
-  await commands.executeCommand(
-    "setContext",
-    ContextKeys.isRustProject,
-    isRustProject
-  );
-  State.getInstance().isRustProject = isRustProject;
+  const registry = createProjectVariantRegistry();
+  const detection = await registry.detect(workspaceFolder);
+  if (detection.kind === "unsupported") {
+    Logger.warn(LoggerSource.extension, detection.reason);
+    await setProjectContext({
+      isPicoProject: false,
+      isRustProject: false,
+      isZephyrProject: false,
+    });
+    State.getInstance().isRustProject = false;
+    State.getInstance().isZephyrProject = false;
 
-  if (!isRustProject) {
-    const cmakeListsFilePath = join(
-      workspaceFolder.uri.fsPath,
-      "CMakeLists.txt"
-    );
-    if (!existsSync(cmakeListsFilePath)) {
-      Logger.warn(
-        LoggerSource.extension,
-        "No CMakeLists.txt in workspace folder has been found."
-      );
-      await commands.executeCommand(
-        "setContext",
-        ContextKeys.isPicoProject,
-        false
-      );
-
-      return;
-    }
-
-    // Set Pico Zephyr Project false by default
-    await commands.executeCommand(
-      "setContext",
-      ContextKeys.isZephyrProject,
-      false
-    );
-
-    const cmakeListsContents = new TextDecoder().decode(
-      await workspace.fs.readFile(Uri.file(cmakeListsFilePath))
-    );
-
-    // Check for zephyr pico project prefix line in CMakeLists.txt
-    if (cmakeListsContents.trimStart().match(CMAKELISTS_ZEPHYR_REGEX)) {
-      Logger.info(LoggerSource.extension, "Project is of type: Zephyr");
-
-      const vb = new VersionBundlesLoader(context.extensionUri);
-      const latest = await vb.getLatest();
-      if (latest === undefined) {
-        Logger.error(
-          LoggerSource.extension,
-          "Failed to get latest version bundle for Zephyr project."
-        );
-
-        void window.showErrorMessage(
-          "Failed to get latest version bundle for Zephyr project."
-        );
-
-        return;
-      }
-
-      const cmakePath = settings.getString(SettingsKey.cmakePath);
-      // TODO: or auto upgrade to latest cmake
-      if (cmakePath === undefined) {
-        Logger.error(
-          LoggerSource.extension,
-          "CMake path not set in settings. Cannot setup Zephyr project."
-        );
-        void window.showErrorMessage(
-          "CMake path not set in settings. Cannot setup Zephyr project."
-        );
-        await commands.executeCommand(
-          "setContext",
-          ContextKeys.isPicoProject,
-          false
-        );
-
-        return;
-      }
-      let cmakeVersion = "";
-      if (cmakePath && cmakePath.includes("/.pico-sdk/cmake")) {
-        const version = /\/\.pico-sdk\/cmake\/([v.0-9A-Za-z-]+)\//.exec(
-          cmakePath
-        )?.[1];
-
-        if (version === undefined) {
-          Logger.error(
-            LoggerSource.extension,
-            "Failed to get CMake version from path in the settings."
-          );
-          await commands.executeCommand(
-            "setContext",
-            ContextKeys.isPicoProject,
-            false
-          );
-
-          return;
-        }
-
-        cmakeVersion = version;
-      }
-
-      const ninjaPath = settings.getString(SettingsKey.ninjaPath);
-      let ninjaVersion = "";
-      if (ninjaPath === undefined) {
-        Logger.error(
-          LoggerSource.extension,
-          "Ninja path not set in settings. Cannot setup Zephyr project."
-        );
-        void window.showErrorMessage(
-          "Ninja path not set in settings. Cannot setup Zephyr project."
-        );
-        await commands.executeCommand(
-          "setContext",
-          ContextKeys.isPicoProject,
-          false
-        );
-
-        return;
-      } else if (ninjaPath && ninjaPath.includes("/.pico-sdk/ninja")) {
-        const version = /\/\.pico-sdk\/ninja\/([v.0-9]+)\//.exec(
-          ninjaPath
-        )?.[1];
-        if (version === undefined) {
-          Logger.error(
-            LoggerSource.extension,
-            "Failed to get Ninja version from path in the settings."
-          );
-          await commands.executeCommand(
-            "setContext",
-            ContextKeys.isPicoProject,
-            false
-          );
-
-          return;
-        }
-
-        ninjaVersion = version;
-      }
-
-      // check for pinned zephyr version in workspace settings
-      const pinnedVersion = settings.getString(SettingsKey.zephyrVersion);
-      if (pinnedVersion !== undefined && pinnedVersion.length > 0) {
-        const systemVersion = await getZephyrVersion();
-        if (systemVersion === undefined) {
-          Logger.error(
-            LoggerSource.extension,
-            "Failed to get system Zephyr version."
-          );
-          void window.showErrorMessage(
-            "Failed to get system Zephyr version. Cannot setup Zephyr project."
-          );
-          // TODO: instead reset zephyr workspace
-          await commands.executeCommand(
-            "setContext",
-            ContextKeys.isPicoProject,
-            false
-          );
-
-          return;
-        }
-
-        if (systemVersion !== pinnedVersion) {
-          // ask user to switch zephyr version
-          const switchVersion = await window.showInformationMessage(
-            `Project Zephyr version (${pinnedVersion}) differs from system ` +
-              `version (${systemVersion}). ` +
-              `Do you want to switch the system version?`,
-            { modal: true },
-            "Yes",
-            "No - Use system version",
-            "No - Pin to system version"
-          );
-
-          if (switchVersion === "Yes") {
-            const switchResult = await updateZephyrVersion(pinnedVersion);
-            if (!switchResult) {
-              void window.showErrorMessage(
-                `Failed to switch Zephyr version to ${pinnedVersion}. ` +
-                  "Cannot setup Zephyr project."
-              );
-              await commands.executeCommand(
-                "setContext",
-                ContextKeys.isPicoProject,
-                false
-              );
-
-              return;
-            } else {
-              void window.showInformationMessage(
-                `Switched Zephyr version to ${pinnedVersion}.`
-              );
-              Logger.info(
-                LoggerSource.extension,
-                `Switched Zephyr version to ${pinnedVersion}.`
-              );
-            }
-          } else if (switchVersion === "No - Pin to system version") {
-            // update workspace settings
-            await settings.update(SettingsKey.zephyrVersion, systemVersion);
-            void window.showInformationMessage(
-              `Pinned Zephyr version to ${systemVersion}.`
-            );
-            Logger.info(
-              LoggerSource.extension,
-              `Pinned Zephyr version to ${systemVersion}.`
-            );
-          }
-        }
-      }
-
-      const result = await setupZephyr({
-        extUri: context.extensionUri,
-        cmakeMode: cmakeVersion !== "" ? 2 : 3,
-        cmakePath:
-          cmakeVersion !== ""
-            ? ""
-            : cmakePath.replace(HOME_VAR, homedir().replaceAll("\\", "/")) ??
-              "",
-        cmakeVersion: cmakeVersion,
-        ninjaMode: ninjaVersion !== "" ? 2 : 3,
-        ninjaPath:
-          ninjaVersion !== ""
-            ? ""
-            : ninjaPath.replace(HOME_VAR, homedir().replaceAll("\\", "/")) ??
-              "",
-        ninjaVersion: ninjaVersion,
-      });
-      if (result === undefined) {
-        void window.showErrorMessage(
-          "Failed to setup Zephyr Toolchain. See logs for details."
-        );
-
-        return;
-      }
-      void window.showInformationMessage(
-        "Zephyr Toolchain setup done. You can now build your project."
-      );
-
-      await commands.executeCommand(
-        "setContext",
-        ContextKeys.isPicoProject,
-        true
-      );
-      await commands.executeCommand(
-        "setContext",
-        ContextKeys.isZephyrProject,
-        true
-      );
-      State.getInstance().isZephyrProject = true;
-
-      ui.showStatusBarItems(false, true);
-      const selectedZephyrVersion = await getZephyrVersion();
-      if (selectedZephyrVersion === undefined) {
-        Logger.error(
-          LoggerSource.extension,
-          "Failed to get selected system Zephyr version. Defaulting to main."
-        );
-      }
-      ui.updateSDKVersion(selectedZephyrVersion ?? "main");
-
-      const cppCompilerUpdated = await updateZephyrCompilerPath(
-        workspaceFolder.uri,
-        selectedZephyrVersion ?? "main"
-      );
-
-      if (!cppCompilerUpdated) {
-        void window.showErrorMessage(
-          "Failed to update C++ compiler path in c_cpp_properties.json"
-        );
-
-        // TODO: maybe cancel activation
-      }
-
-      // Update the board info if it can be found in tasks.json
-      const tasksJsonFilePath = join(
-        workspaceFolder.uri.fsPath,
-        ".vscode",
-        "tasks.json"
-      );
-
-      // Update UI with board description
-      const board = await getBoardFromZephyrProject(tasksJsonFilePath);
-
-      if (board !== undefined) {
-        if (board === ZEPHYR_PICO2_W) {
-          ui.updateBoard("Pico 2W");
-        } else if (board === ZEPHYR_PICO2) {
-          ui.updateBoard("Pico 2");
-        } else if (board === ZEPHYR_PICO_W) {
-          ui.updateBoard("Pico W");
-        } else if (board === ZEPHYR_PICO) {
-          ui.updateBoard("Pico");
-        } else {
-          ui.updateBoard("Other");
-        }
-      }
-
-      await zephyrVerifyCMakeCache(workspaceFolder.uri);
-
-      if (settings.getBoolean(SettingsKey.cmakeAutoConfigure)) {
-        await cmakeSetupAutoConfigure(workspaceFolder, ui);
-      } else {
-        // check if build dir is empty and recommend to run a build to
-        // get the intellisense working
-        const buildUri = Uri.file(join(workspaceFolder.uri.fsPath, "build"));
-        try {
-          // workaround to stop verbose logging of readDirectory
-          // internals even if we catch the error
-          await workspace.fs.stat(buildUri);
-          const buildDirContents = await workspace.fs.readDirectory(buildUri);
-
-          if (buildDirContents.length === 0) {
-            void window.showWarningMessage(
-              "To get full intellisense support please build the project once."
-            );
-          }
-        } catch (error) {
-          if (
-            error instanceof FileSystemError &&
-            error.code === "FileNotFound"
-          ) {
-            void window.showWarningMessage(
-              "To get full intellisense support please build the project once."
-            );
-
-            Logger.debug(
-              LoggerSource.extension,
-              'No "build" folder found. Intellisense might not work ' +
-                "properly until a build has been done."
-            );
-          } else {
-            Logger.error(
-              LoggerSource.extension,
-              "Error when reading build folder:",
-              unknownErrorToString(error)
-            );
-          }
-        }
-      }
-
-      return;
-    }
-    // check for pico_sdk_init() in CMakeLists.txt
-    else if (!cmakeListsContents.includes("pico_sdk_init()")) {
-      Logger.warn(
-        LoggerSource.extension,
-        "No pico_sdk_init() in CMakeLists.txt found."
-      );
-      await commands.executeCommand(
-        "setContext",
-        ContextKeys.isPicoProject,
-        false
-      );
-
-      return;
-    }
-
-    // check if it has .vscode folder and cmake donotedit header in CMakelists.txt
-    if (
-      !existsSync(join(workspaceFolder.uri.fsPath, ".vscode")) ||
-      !(
-        readFileSync(cmakeListsFilePath)
-          .toString("utf-8")
-          .includes(CMAKE_DO_NOT_EDIT_HEADER_PREFIX) ||
-        readFileSync(cmakeListsFilePath)
-          .toString("utf-8")
-          .includes(CMAKE_DO_NOT_EDIT_HEADER_PREFIX_OLD)
-      )
-    ) {
-      Logger.warn(
-        LoggerSource.extension,
-        "No .vscode folder and/or cmake",
-        '"DO NOT EDIT"-header in CMakelists.txt found.'
-      );
-      await commands.executeCommand(
-        "setContext",
-        ContextKeys.isPicoProject,
-        false
-      );
+    if (detection.offerImport) {
       const wantToImport = await window.showInformationMessage(
         "Do you want to import this project as Raspberry Pi Pico project?",
         "Yes",
@@ -670,600 +246,44 @@ export async function activate(context: ExtensionContext): Promise<void> {
           workspaceFolder.uri
         );
       }
-
-      return;
-    }
-  }
-
-  await commands.executeCommand("setContext", ContextKeys.isPicoProject, true);
-
-  if (isRustProject) {
-    const vs = new VersionBundlesLoader(context.extensionUri);
-    const latestSDK = await vs.getLatestSDK();
-    if (!latestSDK) {
-      Logger.error(
-        LoggerSource.extension,
-        "Failed to get latest Pico SDK version for Rust project."
-      );
-      void window.showErrorMessage(
-        "Failed to get latest Pico SDK version for Rust project."
-      );
-
-      return;
-    }
-
-    const sdk = await window.withProgress(
-      {
-        location: ProgressLocation.Notification,
-        title:
-          "Downloading and installing latest Pico SDK (" +
-          latestSDK +
-          "). This may take a while...",
-        cancellable: false,
-      },
-      async progress => {
-        const result = await downloadAndInstallSDK(
-          context.extensionUri,
-          latestSDK,
-          SDK_REPOSITORY_URL
-        );
-
-        progress.report({
-          increment: 100,
-        });
-
-        if (!result) {
-          installSuccess = false;
-
-          Logger.error(
-            LoggerSource.extension,
-            "Failed to install latest SDK",
-            `version: ${latestSDK}.`,
-            "Make sure all requirements are met."
-          );
-
-          void window.showErrorMessage(
-            "Failed to install latest SDK version for rust project."
-          );
-
-          return false;
-        } else {
-          Logger.info(
-            LoggerSource.extension,
-            "Found/installed latest SDK",
-            `version: ${latestSDK}`
-          );
-
-          return true;
-        }
-      }
-    );
-    if (!sdk) {
-      return;
-    }
-
-    const cargo = await window.withProgress(
-      {
-        location: ProgressLocation.Notification,
-        title: "Downloading and installing Rust. This may take a while...",
-        cancellable: false,
-      },
-      async () => downloadAndInstallRust()
-    );
-    if (!cargo) {
-      void window.showErrorMessage("Failed to install Rust.");
-
-      return;
-    }
-
-    const result = await installLatestRustRequirements(context.extensionUri);
-
-    if (!result) {
-      return;
-    }
-
-    ui.showStatusBarItems(isRustProject);
-
-    const chip = rustProjectGetSelectedChip(workspaceFolder.uri.fsPath);
-    if (chip !== null) {
-      ui.updateBoard(chip.toUpperCase());
-    } else {
-      ui.updateBoard("N/A");
     }
 
     return;
   }
 
-  // get sdk selected in the project
-  const selectedToolchainAndSDKVersions =
-    await cmakeGetSelectedToolchainAndSDKVersions(workspaceFolder.uri);
-  if (selectedToolchainAndSDKVersions === null) {
+  const variant = registry.get(detection.variant);
+  await setProjectContext(variant.context);
+  State.getInstance().isRustProject = variant.context.isRustProject;
+  State.getInstance().isZephyrProject = variant.context.isZephyrProject;
+
+  const selections = await variant.readSelections(workspaceFolder);
+  if (selections === null) {
     return;
   }
 
-  // get all available toolchains for download link of current selected one
-  const toolchains = await getSupportedToolchains(context.extensionUri);
-  const selectedToolchain = toolchains.find(
-    toolchain => toolchain.version === selectedToolchainAndSDKVersions[1]
-  );
-
-  // TODO: for failed installation message add option to change version
-  let installSuccess = true;
-  // install if needed
-  await window.withProgress(
-    {
-      location: ProgressLocation.Notification,
-      title:
-        "Downloading and installing Pico SDK as selected. " +
-        "This may take a while...",
-      cancellable: false,
-    },
-    async progress => {
-      const result = await downloadAndInstallSDK(
-        context.extensionUri,
-        selectedToolchainAndSDKVersions[0],
-        SDK_REPOSITORY_URL
-      );
-
-      progress.report({
-        increment: 100,
-      });
-
-      if (!result) {
-        installSuccess = false;
-
-        Logger.error(
-          LoggerSource.extension,
-          "Failed to install project SDK",
-          `version: ${selectedToolchainAndSDKVersions[0]}.`,
-          "Make sure all requirements are met."
-        );
-
-        void window.showErrorMessage("Failed to install project SDK version.");
-
-        return;
-      } else {
-        Logger.info(
-          LoggerSource.extension,
-          "Found/installed project SDK",
-          `version: ${selectedToolchainAndSDKVersions[0]}`
-        );
-      }
-    }
-  );
-
-  if (!installSuccess) {
-    return;
-  }
-
-  if (selectedToolchain === undefined) {
-    Logger.error(
-      LoggerSource.extension,
-      "Failed to detect project toolchain version."
-    );
-
-    void window.showErrorMessage("Failed to detect project toolchain version.");
-
-    return;
-  }
-
-  let progressState = 0;
-  await window.withProgress(
-    {
-      location: ProgressLocation.Notification,
-      title:
-        "Downloading and installing toolchain as selected. " +
-        "This may take a while...",
-      cancellable: false,
-    },
-    async progress => {
-      const result = await downloadAndInstallToolchain(
-        selectedToolchain,
-        (prog: GotProgress) => {
-          const percent = prog.percent * 100;
-          progress.report({
-            increment: percent - progressState,
-          });
-          progressState = percent;
-        }
-      );
-
-      progress.report({
-        increment: 100,
-      });
-
-      if (!result) {
-        installSuccess = false;
-
-        Logger.error(
-          LoggerSource.extension,
-          "Failed to install project toolchain",
-          `version: ${selectedToolchainAndSDKVersions[1]}`
-        );
-
-        void window.showErrorMessage(
-          "Failed to install project toolchain version."
-        );
-
-        return;
-      } else {
-        Logger.info(
-          LoggerSource.extension,
-          "Found/installed project toolchain",
-          `version: ${selectedToolchainAndSDKVersions[1]}`
-        );
-      }
-    }
-  );
-
-  if (!installSuccess) {
-    return;
-  }
-
-  progressState = 0;
-  await window.withProgress(
-    {
-      location: ProgressLocation.Notification,
-      title:
-        "Downloading and installing tools as selected. " +
-        "This may take a while...",
-      cancellable: false,
-    },
-    async progress => {
-      const result = await downloadAndInstallTools(
-        selectedToolchainAndSDKVersions[0],
-        (prog: GotProgress) => {
-          const percent = prog.percent * 100;
-          progress.report({
-            increment: percent - progressState,
-          });
-          progressState = percent;
-        }
-      );
-
-      progress.report({
-        increment: 100,
-      });
-
-      if (!result) {
-        installSuccess = false;
-
-        Logger.error(
-          LoggerSource.extension,
-          "Failed to install project SDK",
-          `version: ${selectedToolchainAndSDKVersions[0]}.`,
-          "Make sure all requirements are met."
-        );
-
-        void window.showErrorMessage("Failed to install project SDK version.");
-
-        return;
-      } else {
-        Logger.info(
-          LoggerSource.extension,
-          "Found/installed project SDK",
-          `version: ${selectedToolchainAndSDKVersions[0]}`
-        );
-      }
-    }
-  );
-
-  if (!installSuccess) {
-    return;
-  }
-
-  progressState = 0;
-  await window.withProgress(
-    {
-      location: ProgressLocation.Notification,
-      title:
-        "Downloading and installing picotool as selected. " +
-        "This may take a while...",
-      cancellable: false,
-    },
-    async progress => {
-      const result = await downloadAndInstallPicotool(
-        selectedToolchainAndSDKVersions[2],
-        (prog: GotProgress) => {
-          const percent = prog.percent * 100;
-          progress.report({
-            increment: percent - progressState,
-          });
-          progressState = percent;
-        }
-      );
-
-      progress.report({
-        increment: 100,
-      });
-
-      if (!result) {
-        installSuccess = false;
-        Logger.error(LoggerSource.extension, "Failed to install picotool.");
-
-        void window.showErrorMessage("Failed to install picotool.");
-
-        return;
-      } else {
-        Logger.debug(LoggerSource.extension, "Found/installed picotool.");
-      }
-    }
-  );
-
-  if (!installSuccess) {
-    return;
-  }
-
-  progressState = 0;
-  await window.withProgress(
-    {
-      location: ProgressLocation.Notification,
-      title: "Downloading and installing OpenOCD. This may take a while...",
-      cancellable: false,
-    },
-    async progress => {
-      const result = await downloadAndInstallOpenOCD(
-        OPENOCD_VERSION,
-        (prog: GotProgress) => {
-          const percent = prog.percent * 100;
-          progress.report({
-            increment: percent - progressState,
-          });
-          progressState = percent;
-        }
-      );
-
-      progress.report({
-        increment: 100,
-      });
-
-      if (!result) {
-        Logger.error(
-          LoggerSource.extension,
-          "Failed to download and install OpenOCD."
-        );
-        void window.showWarningMessage(
-          "Failed to download and install OpenOCD."
-        );
-      } else {
-        Logger.debug(LoggerSource.extension, "Found/installed OpenOCD.");
-
-        void window.showInformationMessage(
-          "OpenOCD found/installed successfully."
-        );
-      }
-    }
-  );
-
-  // TODO: move this ninja, cmake and python installs out of extension.mts
-  const ninjaPath = settings.getString(SettingsKey.ninjaPath);
-  if (ninjaPath && ninjaPath.includes("/.pico-sdk/ninja")) {
-    // check if ninja path exists
-    if (!existsSync(ensureExe(ninjaPath.replace(HOME_VAR, homedir())))) {
-      Logger.debug(
-        LoggerSource.extension,
-        "Ninja path in settings does not exist.",
-        "Installing ninja to default path."
-      );
-      const ninjaVersion = /\/\.pico-sdk\/ninja\/([v.0-9]+)\//.exec(
-        ninjaPath
-      )?.[1];
-      if (ninjaVersion === undefined) {
-        Logger.error(
-          LoggerSource.extension,
-          "Failed to get ninja version from path in the settings."
-        );
-        await commands.executeCommand(
-          "setContext",
-          ContextKeys.isPicoProject,
-          false
-        );
-
-        return;
-      }
-
-      let result = false;
-      progressState = 0;
-      await window.withProgress(
-        {
-          location: ProgressLocation.Notification,
-          title: "Downloading and installing Ninja. This may take a while...",
-          cancellable: false,
-        },
-        async progress => {
-          result = await downloadAndInstallNinja(
-            ninjaVersion,
-            (prog: GotProgress) => {
-              const percent = prog.percent * 100;
-              progress.report({
-                increment: percent - progressState,
-              });
-              progressState = percent;
-            }
-          );
-          progress.report({
-            increment: 100,
-          });
-        }
-      );
-
-      if (!result) {
-        Logger.error(LoggerSource.extension, "Failed to install ninja.");
-        await commands.executeCommand(
-          "setContext",
-          ContextKeys.isPicoProject,
-          false
-        );
-
-        return;
-      }
-      Logger.debug(
-        LoggerSource.extension,
-        "Installed selected ninja for project."
-      );
-    }
-  }
-
-  const cmakePath = settings.getString(SettingsKey.cmakePath);
-  if (cmakePath && cmakePath.includes("/.pico-sdk/cmake")) {
-    // check if cmake path exists
-    if (!existsSync(ensureExe(cmakePath.replace(HOME_VAR, homedir())))) {
-      Logger.warn(
-        LoggerSource.extension,
-        "CMake path in settings does not exist.",
-        "Installing CMake to default path."
-      );
-
-      const cmakeVersion = /\/\.pico-sdk\/cmake\/([v.0-9A-Za-z-]+)\//.exec(
-        cmakePath
-      )?.[1];
-      if (cmakeVersion === undefined) {
-        Logger.error(
-          LoggerSource.extension,
-          "Failed to get CMake version from path in the settings."
-        );
-        await commands.executeCommand(
-          "setContext",
-          ContextKeys.isPicoProject,
-          false
-        );
-
-        return;
-      }
-
-      let result = false;
-      progressState = 0;
-      await window.withProgress(
-        {
-          location: ProgressLocation.Notification,
-          title: "Downloading and installing CMake. This may take a while...",
-          cancellable: false,
-        },
-        async progress => {
-          result = await downloadAndInstallCmake(
-            cmakeVersion,
-            (prog: GotProgress) => {
-              const percent = prog.percent * 100;
-              progress.report({
-                increment: percent - progressState,
-              });
-              progressState = percent;
-            }
-          );
-          progress.report({
-            increment: 100,
-          });
-        }
-      );
-
-      if (!result) {
-        Logger.error(LoggerSource.extension, "Failed to install CMake.");
-        await commands.executeCommand(
-          "setContext",
-          ContextKeys.isPicoProject,
-          false
-        );
-
-        return;
-      }
-      Logger.debug(
-        LoggerSource.extension,
-        "Installed selected cmake for project."
-      );
-    }
-  }
-
-  const pythonPath = await findPython();
-  if (!pythonPath) {
-    Logger.error(LoggerSource.extension, "Failed to find Python3 executable.");
-    await commands.executeCommand(
-      "setContext",
-      ContextKeys.isPicoProject,
-      false
-    );
-    showPythonNotFoundError();
-
-    return;
-  }
-
-  ui.showStatusBarItems();
-  ui.updateSDKVersion(selectedToolchainAndSDKVersions[0]);
-
-  const selectedBoard = cmakeGetSelectedBoard(workspaceFolder.uri);
-  if (selectedBoard !== null) {
-    ui.updateBoard(selectedBoard);
-  } else {
-    ui.updateBoard("unknown");
-  }
-
-  // auto project configuration with cmake
-  if (settings.getBoolean(SettingsKey.cmakeAutoConfigure)) {
-    await cmakeSetupAutoConfigure(workspaceFolder, ui);
-  } else if (settings.getBoolean(SettingsKey.useCmakeTools)) {
-    // Ensure the Pico kit is selected
-    const kitForced = await cmakeToolsForcePicoKit();
-    if (!kitForced) {
-      Logger.warn(LoggerSource.extension,
-        "Failed to force Pico kit in CMake Tools - attempting to do it later"
-      );
-
-      setTimeout(() => {
-        void cmakeToolsForcePicoKit().catch(error => {
-          Logger.error(LoggerSource.extension,
-            "Failed to force Pico kit in CMake Tools on second attempt",
-            unknownErrorToString(error)
-          );
-        });
-      }, 1000);
-    }
-  } else {
-    Logger.info(
-      LoggerSource.extension,
-      "No workspace folder for configuration found",
-      "or cmakeAutoConfigure disabled."
-    );
-  }
-}
-
-async function cmakeSetupAutoConfigure(
-  workspaceFolder: WorkspaceFolder,
-  ui: UI
-): Promise<void> {
-  //run `cmake -G Ninja -B ./build ` in the root folder
-  await configureCmakeNinja(workspaceFolder.uri);
-
-  const ws = workspaceFolder.uri.fsPath;
-  const cMakeCachePath = join(ws, "build", "CMakeCache.txt");
-  const newBuildType = cmakeGetPicoVar(cMakeCachePath, "CMAKE_BUILD_TYPE");
-  ui.updateBuildType(newBuildType ?? "unknown");
-
-  workspace.onDidChangeTextDocument(event => {
-    // Check if the changed document is the file you are interested in
-    if (basename(event.document.fileName) === "CMakeLists.txt") {
-      // File has changed, do something here
-      // TODO: rerun configure project
-      // TODO: maybe conflicts with cmake extension which also does this
-      Logger.debug(
-        LoggerSource.extension,
-        "File changed:",
-        event.document.fileName
-      );
-    }
+  const dependenciesReady = await variant.ensureDependencies({
+    context,
+    folder: workspaceFolder,
+    selections,
+    settings,
   });
-}
+  if (!dependenciesReady) {
+    return;
+  }
 
-/**
- * Make sure the executable has the .exe extension on Windows.
- *
- * @param inp - The input string.
- * @returns The input string with .exe extension if on Windows.
- */
-function ensureExe(inp: string): string {
-  return process.platform === "win32"
-    ? inp.endsWith(".exe")
-      ? inp
-      : `${inp}.exe`
-    : inp;
+  await variant.updateUi({ ui, selections });
+
+  const activated =
+    (await variant.afterActivation?.({
+      context,
+      folder: workspaceFolder,
+      selections,
+      settings,
+      ui,
+    })) ?? true;
+  if (!activated) {
+    return;
+  }
 }
 
 export function deactivate(): void {

--- a/src/projectVariants/cCppVariant.mts
+++ b/src/projectVariants/cCppVariant.mts
@@ -29,9 +29,9 @@ import type {
   UpdateProjectUiInput,
 } from "./types.mjs";
 import {
-  ensureBasePicoDependencies,
   ensureManagedTool,
 } from "./common.mjs";
+import { ensureBasePicoDependencies } from "../utils/picoDependencies.mjs";
 import { cmakeSetupAutoConfigure } from "./cmakeActivation.mjs";
 
 export class CCppProjectVariant implements PicoProjectVariant {

--- a/src/projectVariants/cCppVariant.mts
+++ b/src/projectVariants/cCppVariant.mts
@@ -1,0 +1,342 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import {
+  commands,
+  ProgressLocation,
+  window,
+  type WorkspaceFolder,
+} from "vscode";
+import Logger, { LoggerSource } from "../logger.mjs";
+import { ContextKeys } from "../contextKeys.mjs";
+import { SettingsKey } from "../settings.mjs";
+import {
+  CMAKE_DO_NOT_EDIT_HEADER_PREFIX,
+  CMAKE_DO_NOT_EDIT_HEADER_PREFIX_OLD,
+  cmakeGetSelectedBoard,
+  cmakeGetSelectedToolchainAndSDKVersions,
+} from "../utils/cmakeUtil.mjs";
+import {
+  downloadAndInstallCmake,
+  downloadAndInstallNinja,
+  downloadAndInstallOpenOCD,
+  downloadAndInstallPicotool,
+  downloadAndInstallSDK,
+  downloadAndInstallToolchain,
+  downloadAndInstallTools,
+} from "../utils/download.mjs";
+import { getSupportedToolchains } from "../utils/toolchainUtil.mjs";
+import findPython, { showPythonNotFoundError } from "../utils/pythonHelper.mjs";
+import {
+  OPENOCD_VERSION,
+  SDK_REPOSITORY_URL,
+} from "../utils/sharedConstants.mjs";
+import { cmakeToolsForcePicoKit } from "../utils/cmakeToolsUtil.mjs";
+import { unknownErrorToString } from "../utils/errorHelper.mjs";
+import type {
+  AfterActivationInput,
+  EnsureDependenciesInput,
+  PicoProjectVariant,
+  ProjectDetectionResult,
+  ProjectSelections,
+  UpdateProjectUiInput,
+} from "./types.mjs";
+import { ensureManagedTool, withDownloadProgress } from "./common.mjs";
+import { cmakeSetupAutoConfigure } from "./cmakeActivation.mjs";
+
+export class CCppProjectVariant implements PicoProjectVariant {
+  public readonly id = "c-cpp";
+  public readonly context = {
+    isPicoProject: true,
+    isRustProject: false,
+    isZephyrProject: false,
+  };
+
+  public detect(folder: WorkspaceFolder): ProjectDetectionResult {
+    const cmakeListsFilePath = join(folder.uri.fsPath, "CMakeLists.txt");
+    if (!existsSync(cmakeListsFilePath)) {
+      return {
+        kind: "unsupported",
+        reason: "No CMakeLists.txt in workspace folder has been found.",
+      };
+    }
+
+    const cmakeListsContents = readFileSync(cmakeListsFilePath, "utf-8");
+    if (!cmakeListsContents.includes("pico_sdk_init()")) {
+      return {
+        kind: "unsupported",
+        reason: "No pico_sdk_init() in CMakeLists.txt found.",
+      };
+    }
+
+    const hasExtensionHeader =
+      cmakeListsContents.includes(CMAKE_DO_NOT_EDIT_HEADER_PREFIX) ||
+      cmakeListsContents.includes(CMAKE_DO_NOT_EDIT_HEADER_PREFIX_OLD);
+    if (
+      !existsSync(join(folder.uri.fsPath, ".vscode")) ||
+      !hasExtensionHeader
+    ) {
+      return {
+        kind: "unsupported",
+        reason:
+          'No .vscode folder and/or cmake "DO NOT EDIT"-header in ' +
+          "CMakeLists.txt found.",
+        offerImport: true,
+      };
+    }
+
+    return { kind: "supported", variant: this.id };
+  }
+
+  public async readSelections(
+    folder: WorkspaceFolder
+  ): Promise<ProjectSelections | null> {
+    const selectedVersions = await cmakeGetSelectedToolchainAndSDKVersions(
+      folder.uri
+    );
+    if (selectedVersions === null) {
+      return null;
+    }
+
+    return {
+      sdkVersion: selectedVersions[0],
+      toolchainVersion: selectedVersions[1],
+      picotoolVersion: selectedVersions[2],
+      boardId: cmakeGetSelectedBoard(folder.uri) ?? undefined,
+      boardLabel: cmakeGetSelectedBoard(folder.uri) ?? "unknown",
+    };
+  }
+
+  public async ensureDependencies(
+    input: EnsureDependenciesInput
+  ): Promise<boolean> {
+    const { context, selections, settings } = input;
+    if (
+      selections.sdkVersion === undefined ||
+      selections.toolchainVersion === undefined ||
+      selections.picotoolVersion === undefined
+    ) {
+      return false;
+    }
+
+    let installSuccess = true;
+    await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title:
+          "Downloading and installing Pico SDK as selected. " +
+          "This may take a while...",
+        cancellable: false,
+      },
+      async progress => {
+        const result = await downloadAndInstallSDK(
+          context.extensionUri,
+          selections.sdkVersion!,
+          SDK_REPOSITORY_URL
+        );
+
+        progress.report({ increment: 100 });
+
+        if (!result) {
+          installSuccess = false;
+          Logger.error(
+            LoggerSource.extension,
+            "Failed to install project SDK",
+            `version: ${selections.sdkVersion}.`,
+            "Make sure all requirements are met."
+          );
+          void window.showErrorMessage(
+            "Failed to install project SDK version."
+          );
+        } else {
+          Logger.info(
+            LoggerSource.extension,
+            "Found/installed project SDK",
+            `version: ${selections.sdkVersion}`
+          );
+        }
+      }
+    );
+    if (!installSuccess) {
+      return false;
+    }
+
+    const toolchains = await getSupportedToolchains(context.extensionUri);
+    const selectedToolchain = toolchains.find(
+      toolchain => toolchain.version === selections.toolchainVersion
+    );
+    if (selectedToolchain === undefined) {
+      Logger.error(
+        LoggerSource.extension,
+        "Failed to detect project toolchain version."
+      );
+      void window.showErrorMessage(
+        "Failed to detect project toolchain version."
+      );
+
+      return false;
+    }
+
+    installSuccess = await withDownloadProgress(
+      "Downloading and installing toolchain as selected. " +
+        "This may take a while...",
+      progress => downloadAndInstallToolchain(selectedToolchain, progress)
+    );
+    if (!installSuccess) {
+      Logger.error(
+        LoggerSource.extension,
+        "Failed to install project toolchain",
+        `version: ${selections.toolchainVersion}`
+      );
+      void window.showErrorMessage(
+        "Failed to install project toolchain version."
+      );
+
+      return false;
+    }
+    Logger.info(
+      LoggerSource.extension,
+      "Found/installed project toolchain",
+      `version: ${selections.toolchainVersion}`
+    );
+
+    installSuccess = await withDownloadProgress(
+      "Downloading and installing tools as selected. This may take a while...",
+      progress => downloadAndInstallTools(selections.sdkVersion!, progress)
+    );
+    if (!installSuccess) {
+      Logger.error(
+        LoggerSource.extension,
+        "Failed to install project SDK",
+        `version: ${selections.sdkVersion}.`,
+        "Make sure all requirements are met."
+      );
+      void window.showErrorMessage("Failed to install project SDK version.");
+
+      return false;
+    }
+    Logger.info(
+      LoggerSource.extension,
+      "Found/installed project SDK",
+      `version: ${selections.sdkVersion}`
+    );
+
+    installSuccess = await withDownloadProgress(
+      "Downloading and installing picotool as selected. " +
+        "This may take a while...",
+      progress =>
+        downloadAndInstallPicotool(selections.picotoolVersion!, progress)
+    );
+    if (!installSuccess) {
+      Logger.error(LoggerSource.extension, "Failed to install picotool.");
+      void window.showErrorMessage("Failed to install picotool.");
+
+      return false;
+    }
+    Logger.debug(LoggerSource.extension, "Found/installed picotool.");
+
+    const openOcdInstalled = await withDownloadProgress(
+      "Downloading and installing OpenOCD. This may take a while...",
+      progress => downloadAndInstallOpenOCD(OPENOCD_VERSION, progress)
+    );
+    if (!openOcdInstalled) {
+      Logger.error(
+        LoggerSource.extension,
+        "Failed to download and install OpenOCD."
+      );
+      void window.showWarningMessage(
+        "Failed to download and install OpenOCD."
+      );
+    } else {
+      Logger.debug(LoggerSource.extension, "Found/installed OpenOCD.");
+      void window.showInformationMessage(
+        "OpenOCD found/installed successfully."
+      );
+    }
+
+    const ninjaInstalled = await ensureManagedTool(
+      settings,
+      "ninja",
+      downloadAndInstallNinja
+    );
+    if (!ninjaInstalled) {
+      await commands.executeCommand(
+        "setContext",
+        ContextKeys.isPicoProject,
+        false
+      );
+
+      return false;
+    }
+
+    const cmakeInstalled = await ensureManagedTool(
+      settings,
+      "cmake",
+      downloadAndInstallCmake
+    );
+    if (!cmakeInstalled) {
+      await commands.executeCommand(
+        "setContext",
+        ContextKeys.isPicoProject,
+        false
+      );
+
+      return false;
+    }
+
+    const pythonPath = await findPython();
+    if (!pythonPath) {
+      Logger.error(
+        LoggerSource.extension,
+        "Failed to find Python3 executable."
+      );
+      await commands.executeCommand(
+        "setContext",
+        ContextKeys.isPicoProject,
+        false
+      );
+      showPythonNotFoundError();
+
+      return false;
+    }
+
+    return true;
+  }
+
+  public updateUi(input: UpdateProjectUiInput): void {
+    input.ui.showStatusBarItems();
+    input.ui.updateSDKVersion(input.selections.sdkVersion ?? "unknown");
+    input.ui.updateBoard(input.selections.boardLabel ?? "unknown");
+  }
+
+  public async afterActivation(input: AfterActivationInput): Promise<boolean> {
+    if (input.settings.getBoolean(SettingsKey.cmakeAutoConfigure)) {
+      await cmakeSetupAutoConfigure(input.folder, input.ui);
+    } else if (input.settings.getBoolean(SettingsKey.useCmakeTools)) {
+      const kitForced = await cmakeToolsForcePicoKit();
+      if (!kitForced) {
+        Logger.warn(
+          LoggerSource.extension,
+          "Failed to force Pico kit in CMake Tools - attempting to do it later"
+        );
+
+        setTimeout(() => {
+          void cmakeToolsForcePicoKit().catch(error => {
+            Logger.error(
+              LoggerSource.extension,
+              "Failed to force Pico kit in CMake Tools on second attempt",
+              unknownErrorToString(error)
+            );
+          });
+        }, 1000);
+      }
+    } else {
+      Logger.info(
+        LoggerSource.extension,
+        "No workspace folder for configuration found",
+        "or cmakeAutoConfigure disabled."
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/projectVariants/cCppVariant.mts
+++ b/src/projectVariants/cCppVariant.mts
@@ -2,7 +2,6 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import {
   commands,
-  ProgressLocation,
   window,
   type WorkspaceFolder,
 } from "vscode";
@@ -20,16 +19,12 @@ import {
   downloadAndInstallNinja,
   downloadAndInstallOpenOCD,
   downloadAndInstallPicotool,
-  downloadAndInstallSDK,
   downloadAndInstallToolchain,
   downloadAndInstallTools,
 } from "../utils/download.mjs";
 import { getSupportedToolchains } from "../utils/toolchainUtil.mjs";
 import findPython, { showPythonNotFoundError } from "../utils/pythonHelper.mjs";
-import {
-  OPENOCD_VERSION,
-  SDK_REPOSITORY_URL,
-} from "../utils/sharedConstants.mjs";
+import { OPENOCD_VERSION } from "../utils/sharedConstants.mjs";
 import { cmakeToolsForcePicoKit } from "../utils/cmakeToolsUtil.mjs";
 import { unknownErrorToString } from "../utils/errorHelper.mjs";
 import type {
@@ -40,7 +35,11 @@ import type {
   ProjectSelections,
   UpdateProjectUiInput,
 } from "./types.mjs";
-import { ensureManagedTool, withDownloadProgress } from "./common.mjs";
+import {
+  ensureManagedTool,
+  ensurePicoSdkInstalled,
+  withDownloadProgress,
+} from "./common.mjs";
 import { cmakeSetupAutoConfigure } from "./cmakeActivation.mjs";
 
 export class CCppProjectVariant implements PicoProjectVariant {
@@ -118,44 +117,16 @@ export class CCppProjectVariant implements PicoProjectVariant {
       return false;
     }
 
-    let installSuccess = true;
-    await window.withProgress(
-      {
-        location: ProgressLocation.Notification,
-        title:
-          "Downloading and installing Pico SDK as selected. " +
-          "This may take a while...",
-        cancellable: false,
-      },
-      async progress => {
-        const result = await downloadAndInstallSDK(
-          context.extensionUri,
-          selections.sdkVersion!,
-          SDK_REPOSITORY_URL
-        );
-
-        progress.report({ increment: 100 });
-
-        if (!result) {
-          installSuccess = false;
-          Logger.error(
-            LoggerSource.extension,
-            "Failed to install project SDK",
-            `version: ${selections.sdkVersion}.`,
-            "Make sure all requirements are met."
-          );
-          void window.showErrorMessage(
-            "Failed to install project SDK version."
-          );
-        } else {
-          Logger.info(
-            LoggerSource.extension,
-            "Found/installed project SDK",
-            `version: ${selections.sdkVersion}`
-          );
-        }
-      }
-    );
+    let installSuccess = await ensurePicoSdkInstalled({
+      extensionUri: context.extensionUri,
+      sdkVersion: selections.sdkVersion,
+      title:
+        "Downloading and installing Pico SDK as selected. " +
+        "This may take a while...",
+      failureMessage: "Failed to install project SDK version.",
+      logFailurePrefix: "Failed to install project SDK",
+      logSuccessPrefix: "Found/installed project SDK",
+    });
     if (!installSuccess) {
       return false;
     }

--- a/src/projectVariants/cCppVariant.mts
+++ b/src/projectVariants/cCppVariant.mts
@@ -2,7 +2,6 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import {
   commands,
-  window,
   type WorkspaceFolder,
 } from "vscode";
 import Logger, { LoggerSource } from "../logger.mjs";
@@ -17,14 +16,8 @@ import {
 import {
   downloadAndInstallCmake,
   downloadAndInstallNinja,
-  downloadAndInstallOpenOCD,
-  downloadAndInstallPicotool,
-  downloadAndInstallToolchain,
-  downloadAndInstallTools,
 } from "../utils/download.mjs";
-import { getSupportedToolchains } from "../utils/toolchainUtil.mjs";
 import findPython, { showPythonNotFoundError } from "../utils/pythonHelper.mjs";
-import { OPENOCD_VERSION } from "../utils/sharedConstants.mjs";
 import { cmakeToolsForcePicoKit } from "../utils/cmakeToolsUtil.mjs";
 import { unknownErrorToString } from "../utils/errorHelper.mjs";
 import type {
@@ -36,9 +29,8 @@ import type {
   UpdateProjectUiInput,
 } from "./types.mjs";
 import {
+  ensureBasePicoDependencies,
   ensureManagedTool,
-  ensurePicoSdkInstalled,
-  withDownloadProgress,
 } from "./common.mjs";
 import { cmakeSetupAutoConfigure } from "./cmakeActivation.mjs";
 
@@ -117,111 +109,18 @@ export class CCppProjectVariant implements PicoProjectVariant {
       return false;
     }
 
-    let installSuccess = await ensurePicoSdkInstalled({
+    const baseDependenciesInstalled = await ensureBasePicoDependencies({
       extensionUri: context.extensionUri,
-      sdkVersion: selections.sdkVersion,
+      selections,
       title:
         "Downloading and installing Pico SDK as selected. " +
         "This may take a while...",
-      failureMessage: "Failed to install project SDK version.",
-      logFailurePrefix: "Failed to install project SDK",
-      logSuccessPrefix: "Found/installed project SDK",
+      sdkFailureMessage: "Failed to install project SDK version.",
+      sdkLogFailurePrefix: "Failed to install project SDK",
+      sdkLogSuccessPrefix: "Found/installed project SDK",
     });
-    if (!installSuccess) {
+    if (!baseDependenciesInstalled) {
       return false;
-    }
-
-    const toolchains = await getSupportedToolchains(context.extensionUri);
-    const selectedToolchain = toolchains.find(
-      toolchain => toolchain.version === selections.toolchainVersion
-    );
-    if (selectedToolchain === undefined) {
-      Logger.error(
-        LoggerSource.extension,
-        "Failed to detect project toolchain version."
-      );
-      void window.showErrorMessage(
-        "Failed to detect project toolchain version."
-      );
-
-      return false;
-    }
-
-    installSuccess = await withDownloadProgress(
-      "Downloading and installing toolchain as selected. " +
-        "This may take a while...",
-      progress => downloadAndInstallToolchain(selectedToolchain, progress)
-    );
-    if (!installSuccess) {
-      Logger.error(
-        LoggerSource.extension,
-        "Failed to install project toolchain",
-        `version: ${selections.toolchainVersion}`
-      );
-      void window.showErrorMessage(
-        "Failed to install project toolchain version."
-      );
-
-      return false;
-    }
-    Logger.info(
-      LoggerSource.extension,
-      "Found/installed project toolchain",
-      `version: ${selections.toolchainVersion}`
-    );
-
-    installSuccess = await withDownloadProgress(
-      "Downloading and installing tools as selected. This may take a while...",
-      progress => downloadAndInstallTools(selections.sdkVersion!, progress)
-    );
-    if (!installSuccess) {
-      Logger.error(
-        LoggerSource.extension,
-        "Failed to install project SDK",
-        `version: ${selections.sdkVersion}.`,
-        "Make sure all requirements are met."
-      );
-      void window.showErrorMessage("Failed to install project SDK version.");
-
-      return false;
-    }
-    Logger.info(
-      LoggerSource.extension,
-      "Found/installed project SDK",
-      `version: ${selections.sdkVersion}`
-    );
-
-    installSuccess = await withDownloadProgress(
-      "Downloading and installing picotool as selected. " +
-        "This may take a while...",
-      progress =>
-        downloadAndInstallPicotool(selections.picotoolVersion!, progress)
-    );
-    if (!installSuccess) {
-      Logger.error(LoggerSource.extension, "Failed to install picotool.");
-      void window.showErrorMessage("Failed to install picotool.");
-
-      return false;
-    }
-    Logger.debug(LoggerSource.extension, "Found/installed picotool.");
-
-    const openOcdInstalled = await withDownloadProgress(
-      "Downloading and installing OpenOCD. This may take a while...",
-      progress => downloadAndInstallOpenOCD(OPENOCD_VERSION, progress)
-    );
-    if (!openOcdInstalled) {
-      Logger.error(
-        LoggerSource.extension,
-        "Failed to download and install OpenOCD."
-      );
-      void window.showWarningMessage(
-        "Failed to download and install OpenOCD."
-      );
-    } else {
-      Logger.debug(LoggerSource.extension, "Found/installed OpenOCD.");
-      void window.showInformationMessage(
-        "OpenOCD found/installed successfully."
-      );
     }
 
     const ninjaInstalled = await ensureManagedTool(

--- a/src/projectVariants/cmakeActivation.mts
+++ b/src/projectVariants/cmakeActivation.mts
@@ -1,0 +1,27 @@
+import { basename, join } from "path";
+import { workspace, type WorkspaceFolder } from "vscode";
+import Logger, { LoggerSource } from "../logger.mjs";
+import type UI from "../ui.mjs";
+import { cmakeGetPicoVar, configureCmakeNinja } from "../utils/cmakeUtil.mjs";
+
+export async function cmakeSetupAutoConfigure(
+  workspaceFolder: WorkspaceFolder,
+  ui: UI
+): Promise<void> {
+  await configureCmakeNinja(workspaceFolder.uri);
+
+  const ws = workspaceFolder.uri.fsPath;
+  const cMakeCachePath = join(ws, "build", "CMakeCache.txt");
+  const newBuildType = cmakeGetPicoVar(cMakeCachePath, "CMAKE_BUILD_TYPE");
+  ui.updateBuildType(newBuildType ?? "unknown");
+
+  workspace.onDidChangeTextDocument(event => {
+    if (basename(event.document.fileName) === "CMakeLists.txt") {
+      Logger.debug(
+        LoggerSource.extension,
+        "File changed:",
+        event.document.fileName
+      );
+    }
+  });
+}

--- a/src/projectVariants/common.mts
+++ b/src/projectVariants/common.mts
@@ -5,10 +5,20 @@ import type { Progress as GotProgress } from "got";
 import Logger, { LoggerSource } from "../logger.mjs";
 import { ContextKeys } from "../contextKeys.mjs";
 import { HOME_VAR, SettingsKey } from "../settings.mjs";
-import { downloadAndInstallSDK } from "../utils/download.mjs";
-import { SDK_REPOSITORY_URL } from "../utils/sharedConstants.mjs";
+import {
+  downloadAndInstallOpenOCD,
+  downloadAndInstallPicotool,
+  downloadAndInstallSDK,
+  downloadAndInstallToolchain,
+  downloadAndInstallTools,
+} from "../utils/download.mjs";
+import {
+  OPENOCD_VERSION,
+  SDK_REPOSITORY_URL,
+} from "../utils/sharedConstants.mjs";
+import { getSupportedToolchains } from "../utils/toolchainUtil.mjs";
 import type Settings from "../settings.mjs";
-import type { ProjectContextFlags } from "./types.mjs";
+import type { ProjectContextFlags, ProjectSelections } from "./types.mjs";
 
 export async function setProjectContext(
   flags: ProjectContextFlags
@@ -56,6 +66,128 @@ export function ensureExe(inp: string): string {
       ? inp
       : `${inp}.exe`
     : inp;
+}
+
+export async function ensureBasePicoDependencies(input: {
+  extensionUri: Uri;
+  selections: ProjectSelections;
+  title: string;
+  sdkFailureMessage: string;
+  sdkLogFailurePrefix: string;
+  sdkLogSuccessPrefix: string;
+  python3Path?: string;
+}): Promise<boolean> {
+  if (
+    input.selections.sdkVersion === undefined ||
+    input.selections.toolchainVersion === undefined ||
+    input.selections.picotoolVersion === undefined
+  ) {
+    return false;
+  }
+
+  const sdkInstalled = await ensurePicoSdkInstalled({
+    extensionUri: input.extensionUri,
+    sdkVersion: input.selections.sdkVersion,
+    python3Path: input.python3Path,
+    title: input.title,
+    failureMessage: input.sdkFailureMessage,
+    logFailurePrefix: input.sdkLogFailurePrefix,
+    logSuccessPrefix: input.sdkLogSuccessPrefix,
+  });
+  if (!sdkInstalled) {
+    return false;
+  }
+
+  const toolchains = await getSupportedToolchains(input.extensionUri);
+  const selectedToolchain = toolchains.find(
+    toolchain => toolchain.version === input.selections.toolchainVersion
+  );
+  if (selectedToolchain === undefined) {
+    Logger.error(
+      LoggerSource.extension,
+      "Failed to detect project toolchain version."
+    );
+    void window.showErrorMessage("Failed to detect project toolchain version.");
+
+    return false;
+  }
+
+  const toolchainInstalled = await withDownloadProgress(
+    "Downloading and installing toolchain as selected. " +
+      "This may take a while...",
+    progress => downloadAndInstallToolchain(selectedToolchain, progress)
+  );
+  if (!toolchainInstalled) {
+    Logger.error(
+      LoggerSource.extension,
+      "Failed to install project toolchain",
+      `version: ${input.selections.toolchainVersion}`
+    );
+    void window.showErrorMessage(
+      "Failed to install project toolchain version."
+    );
+
+    return false;
+  }
+  Logger.info(
+    LoggerSource.extension,
+    "Found/installed project toolchain",
+    `version: ${input.selections.toolchainVersion}`
+  );
+
+  const toolsInstalled = await withDownloadProgress(
+    "Downloading and installing tools as selected. This may take a while...",
+    progress => downloadAndInstallTools(input.selections.sdkVersion!, progress)
+  );
+  if (!toolsInstalled) {
+    Logger.error(
+      LoggerSource.extension,
+      "Failed to install project SDK",
+      `version: ${input.selections.sdkVersion}.`,
+      "Make sure all requirements are met."
+    );
+    void window.showErrorMessage("Failed to install project SDK version.");
+
+    return false;
+  }
+  Logger.info(
+    LoggerSource.extension,
+    "Found/installed project SDK",
+    `version: ${input.selections.sdkVersion}`
+  );
+
+  const picotoolInstalled = await withDownloadProgress(
+    "Downloading and installing picotool as selected. " +
+      "This may take a while...",
+    progress => downloadAndInstallPicotool(
+      input.selections.picotoolVersion!,
+      progress
+    )
+  );
+  if (!picotoolInstalled) {
+    Logger.error(LoggerSource.extension, "Failed to install picotool.");
+    void window.showErrorMessage("Failed to install picotool.");
+
+    return false;
+  }
+  Logger.debug(LoggerSource.extension, "Found/installed picotool.");
+
+  const openOcdInstalled = await withDownloadProgress(
+    "Downloading and installing OpenOCD. This may take a while...",
+    progress => downloadAndInstallOpenOCD(OPENOCD_VERSION, progress)
+  );
+  if (!openOcdInstalled) {
+    Logger.error(
+      LoggerSource.extension,
+      "Failed to download and install OpenOCD."
+    );
+    void window.showWarningMessage("Failed to download and install OpenOCD.");
+  } else {
+    Logger.debug(LoggerSource.extension, "Found/installed OpenOCD.");
+    void window.showInformationMessage("OpenOCD found/installed successfully.");
+  }
+
+  return true;
 }
 
 export async function ensurePicoSdkInstalled(input: {

--- a/src/projectVariants/common.mts
+++ b/src/projectVariants/common.mts
@@ -1,10 +1,12 @@
 import { existsSync } from "fs";
 import { homedir } from "os";
-import { commands, ProgressLocation, window } from "vscode";
+import { commands, ProgressLocation, window, type Uri } from "vscode";
 import type { Progress as GotProgress } from "got";
 import Logger, { LoggerSource } from "../logger.mjs";
 import { ContextKeys } from "../contextKeys.mjs";
 import { HOME_VAR, SettingsKey } from "../settings.mjs";
+import { downloadAndInstallSDK } from "../utils/download.mjs";
+import { SDK_REPOSITORY_URL } from "../utils/sharedConstants.mjs";
 import type Settings from "../settings.mjs";
 import type { ProjectContextFlags } from "./types.mjs";
 
@@ -54,6 +56,56 @@ export function ensureExe(inp: string): string {
       ? inp
       : `${inp}.exe`
     : inp;
+}
+
+export async function ensurePicoSdkInstalled(input: {
+  extensionUri: Uri;
+  sdkVersion: string;
+  python3Path?: string;
+  title: string;
+  failureMessage: string;
+  logFailurePrefix: string;
+  logSuccessPrefix: string;
+}): Promise<boolean> {
+  const result = await window.withProgress(
+    {
+      location: ProgressLocation.Notification,
+      title: input.title,
+      cancellable: false,
+    },
+    async progress => {
+      const installResult = await downloadAndInstallSDK(
+        input.extensionUri,
+        input.sdkVersion,
+        SDK_REPOSITORY_URL,
+        input.python3Path
+      );
+
+      progress.report({ increment: 100 });
+
+      return installResult;
+    }
+  );
+
+  if (!result) {
+    Logger.error(
+      LoggerSource.extension,
+      input.logFailurePrefix,
+      `version: ${input.sdkVersion}.`,
+      "Make sure all requirements are met."
+    );
+    void window.showErrorMessage(input.failureMessage);
+
+    return false;
+  }
+
+  Logger.info(
+    LoggerSource.extension,
+    input.logSuccessPrefix,
+    `version: ${input.sdkVersion}`
+  );
+
+  return true;
 }
 
 export async function ensureManagedTool(

--- a/src/projectVariants/common.mts
+++ b/src/projectVariants/common.mts
@@ -1,0 +1,139 @@
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { commands, ProgressLocation, window } from "vscode";
+import type { Progress as GotProgress } from "got";
+import Logger, { LoggerSource } from "../logger.mjs";
+import { ContextKeys } from "../contextKeys.mjs";
+import { HOME_VAR, SettingsKey } from "../settings.mjs";
+import type Settings from "../settings.mjs";
+import type { ProjectContextFlags } from "./types.mjs";
+
+export async function setProjectContext(
+  flags: ProjectContextFlags
+): Promise<void> {
+  await commands.executeCommand(
+    "setContext",
+    ContextKeys.isPicoProject,
+    flags.isPicoProject
+  );
+  await commands.executeCommand(
+    "setContext",
+    ContextKeys.isRustProject,
+    flags.isRustProject
+  );
+  await commands.executeCommand(
+    "setContext",
+    ContextKeys.isZephyrProject,
+    flags.isZephyrProject
+  );
+}
+
+export function selectedManagedToolVersion(
+  path: string | undefined,
+  tool: "cmake" | "ninja"
+): string | undefined {
+  if (path === undefined || !path.includes(`/.pico-sdk/${tool}`)) {
+    return undefined;
+  }
+
+  const regex =
+    tool === "cmake"
+      ? /\/\.pico-sdk\/cmake\/([v.0-9A-Za-z-]+)\//
+      : /\/\.pico-sdk\/ninja\/([v.0-9]+)\//;
+
+  return regex.exec(path)?.[1];
+}
+
+export function resolveHomePath(path: string): string {
+  return path.replace(HOME_VAR, homedir().replaceAll("\\", "/"));
+}
+
+export function ensureExe(inp: string): string {
+  return process.platform === "win32"
+    ? inp.endsWith(".exe")
+      ? inp
+      : `${inp}.exe`
+    : inp;
+}
+
+export async function ensureManagedTool(
+  settings: Settings,
+  tool: "cmake" | "ninja",
+  installer: (
+    version: string,
+    progress?: (progress: GotProgress) => void
+  ) => Promise<boolean>
+): Promise<boolean> {
+  const settingKey =
+    tool === "cmake" ? SettingsKey.cmakePath : SettingsKey.ninjaPath;
+  const configuredPath = settings.getString(settingKey);
+  const version = selectedManagedToolVersion(configuredPath, tool);
+  if (configuredPath === undefined || version === undefined) {
+    return true;
+  }
+
+  if (existsSync(ensureExe(configuredPath.replace(HOME_VAR, homedir())))) {
+    return true;
+  }
+
+  Logger.debug(
+    LoggerSource.extension,
+    `${tool} path in settings does not exist.`,
+    `Installing ${tool} to default path.`
+  );
+
+  let progressState = 0;
+  const result = await window.withProgress(
+    {
+      location: ProgressLocation.Notification,
+      title: `Downloading and installing ${
+        tool === "cmake" ? "CMake" : "Ninja"
+      }. This may take a while...`,
+      cancellable: false,
+    },
+    async progress => {
+      const installResult = await installer(version, (prog: GotProgress) => {
+        const percent = prog.percent * 100;
+        progress.report({ increment: percent - progressState });
+        progressState = percent;
+      });
+      progress.report({ increment: 100 });
+
+      return installResult;
+    }
+  );
+
+  if (!result) {
+    Logger.error(
+      LoggerSource.extension,
+      `Failed to install ${tool === "cmake" ? "CMake" : "ninja"}.`
+    );
+  }
+
+  return result;
+}
+
+export async function withDownloadProgress(
+  title: string,
+  action: (progress?: (progress: GotProgress) => void) => Promise<boolean>
+): Promise<boolean> {
+  let progressState = 0;
+
+  return window.withProgress(
+    {
+      location: ProgressLocation.Notification,
+      title,
+      cancellable: false,
+    },
+    async progress => {
+      const result = await action((prog: GotProgress) => {
+        const percent = prog.percent * 100;
+        progress.report({ increment: percent - progressState });
+        progressState = percent;
+      });
+      progress.report({ increment: 100 });
+
+      return result;
+    }
+  );
+}

--- a/src/projectVariants/common.mts
+++ b/src/projectVariants/common.mts
@@ -1,24 +1,12 @@
 import { existsSync } from "fs";
 import { homedir } from "os";
-import { commands, ProgressLocation, window, type Uri } from "vscode";
+import { commands, ProgressLocation, window } from "vscode";
 import type { Progress as GotProgress } from "got";
 import Logger, { LoggerSource } from "../logger.mjs";
 import { ContextKeys } from "../contextKeys.mjs";
 import { HOME_VAR, SettingsKey } from "../settings.mjs";
-import {
-  downloadAndInstallOpenOCD,
-  downloadAndInstallPicotool,
-  downloadAndInstallSDK,
-  downloadAndInstallToolchain,
-  downloadAndInstallTools,
-} from "../utils/download.mjs";
-import {
-  OPENOCD_VERSION,
-  SDK_REPOSITORY_URL,
-} from "../utils/sharedConstants.mjs";
-import { getSupportedToolchains } from "../utils/toolchainUtil.mjs";
 import type Settings from "../settings.mjs";
-import type { ProjectContextFlags, ProjectSelections } from "./types.mjs";
+import type { ProjectContextFlags } from "./types.mjs";
 
 export async function setProjectContext(
   flags: ProjectContextFlags
@@ -66,178 +54,6 @@ export function ensureExe(inp: string): string {
       ? inp
       : `${inp}.exe`
     : inp;
-}
-
-export async function ensureBasePicoDependencies(input: {
-  extensionUri: Uri;
-  selections: ProjectSelections;
-  title: string;
-  sdkFailureMessage: string;
-  sdkLogFailurePrefix: string;
-  sdkLogSuccessPrefix: string;
-  python3Path?: string;
-}): Promise<boolean> {
-  if (
-    input.selections.sdkVersion === undefined ||
-    input.selections.toolchainVersion === undefined ||
-    input.selections.picotoolVersion === undefined
-  ) {
-    return false;
-  }
-
-  const sdkInstalled = await ensurePicoSdkInstalled({
-    extensionUri: input.extensionUri,
-    sdkVersion: input.selections.sdkVersion,
-    python3Path: input.python3Path,
-    title: input.title,
-    failureMessage: input.sdkFailureMessage,
-    logFailurePrefix: input.sdkLogFailurePrefix,
-    logSuccessPrefix: input.sdkLogSuccessPrefix,
-  });
-  if (!sdkInstalled) {
-    return false;
-  }
-
-  const toolchains = await getSupportedToolchains(input.extensionUri);
-  const selectedToolchain = toolchains.find(
-    toolchain => toolchain.version === input.selections.toolchainVersion
-  );
-  if (selectedToolchain === undefined) {
-    Logger.error(
-      LoggerSource.extension,
-      "Failed to detect project toolchain version."
-    );
-    void window.showErrorMessage("Failed to detect project toolchain version.");
-
-    return false;
-  }
-
-  const toolchainInstalled = await withDownloadProgress(
-    "Downloading and installing toolchain as selected. " +
-      "This may take a while...",
-    progress => downloadAndInstallToolchain(selectedToolchain, progress)
-  );
-  if (!toolchainInstalled) {
-    Logger.error(
-      LoggerSource.extension,
-      "Failed to install project toolchain",
-      `version: ${input.selections.toolchainVersion}`
-    );
-    void window.showErrorMessage(
-      "Failed to install project toolchain version."
-    );
-
-    return false;
-  }
-  Logger.info(
-    LoggerSource.extension,
-    "Found/installed project toolchain",
-    `version: ${input.selections.toolchainVersion}`
-  );
-
-  const toolsInstalled = await withDownloadProgress(
-    "Downloading and installing tools as selected. This may take a while...",
-    progress => downloadAndInstallTools(input.selections.sdkVersion!, progress)
-  );
-  if (!toolsInstalled) {
-    Logger.error(
-      LoggerSource.extension,
-      "Failed to install project SDK",
-      `version: ${input.selections.sdkVersion}.`,
-      "Make sure all requirements are met."
-    );
-    void window.showErrorMessage("Failed to install project SDK version.");
-
-    return false;
-  }
-  Logger.info(
-    LoggerSource.extension,
-    "Found/installed project SDK",
-    `version: ${input.selections.sdkVersion}`
-  );
-
-  const picotoolInstalled = await withDownloadProgress(
-    "Downloading and installing picotool as selected. " +
-      "This may take a while...",
-    progress => downloadAndInstallPicotool(
-      input.selections.picotoolVersion!,
-      progress
-    )
-  );
-  if (!picotoolInstalled) {
-    Logger.error(LoggerSource.extension, "Failed to install picotool.");
-    void window.showErrorMessage("Failed to install picotool.");
-
-    return false;
-  }
-  Logger.debug(LoggerSource.extension, "Found/installed picotool.");
-
-  const openOcdInstalled = await withDownloadProgress(
-    "Downloading and installing OpenOCD. This may take a while...",
-    progress => downloadAndInstallOpenOCD(OPENOCD_VERSION, progress)
-  );
-  if (!openOcdInstalled) {
-    Logger.error(
-      LoggerSource.extension,
-      "Failed to download and install OpenOCD."
-    );
-    void window.showWarningMessage("Failed to download and install OpenOCD.");
-  } else {
-    Logger.debug(LoggerSource.extension, "Found/installed OpenOCD.");
-    void window.showInformationMessage("OpenOCD found/installed successfully.");
-  }
-
-  return true;
-}
-
-export async function ensurePicoSdkInstalled(input: {
-  extensionUri: Uri;
-  sdkVersion: string;
-  python3Path?: string;
-  title: string;
-  failureMessage: string;
-  logFailurePrefix: string;
-  logSuccessPrefix: string;
-}): Promise<boolean> {
-  const result = await window.withProgress(
-    {
-      location: ProgressLocation.Notification,
-      title: input.title,
-      cancellable: false,
-    },
-    async progress => {
-      const installResult = await downloadAndInstallSDK(
-        input.extensionUri,
-        input.sdkVersion,
-        SDK_REPOSITORY_URL,
-        input.python3Path
-      );
-
-      progress.report({ increment: 100 });
-
-      return installResult;
-    }
-  );
-
-  if (!result) {
-    Logger.error(
-      LoggerSource.extension,
-      input.logFailurePrefix,
-      `version: ${input.sdkVersion}.`,
-      "Make sure all requirements are met."
-    );
-    void window.showErrorMessage(input.failureMessage);
-
-    return false;
-  }
-
-  Logger.info(
-    LoggerSource.extension,
-    input.logSuccessPrefix,
-    `version: ${input.sdkVersion}`
-  );
-
-  return true;
 }
 
 export async function ensureManagedTool(
@@ -295,29 +111,4 @@ export async function ensureManagedTool(
   }
 
   return result;
-}
-
-export async function withDownloadProgress(
-  title: string,
-  action: (progress?: (progress: GotProgress) => void) => Promise<boolean>
-): Promise<boolean> {
-  let progressState = 0;
-
-  return window.withProgress(
-    {
-      location: ProgressLocation.Notification,
-      title,
-      cancellable: false,
-    },
-    async progress => {
-      const result = await action((prog: GotProgress) => {
-        const percent = prog.percent * 100;
-        progress.report({ increment: percent - progressState });
-        progressState = percent;
-      });
-      progress.report({ increment: 100 });
-
-      return result;
-    }
-  );
 }

--- a/src/projectVariants/common.mts
+++ b/src/projectVariants/common.mts
@@ -32,7 +32,7 @@ export function selectedManagedToolVersion(
   path: string | undefined,
   tool: "cmake" | "ninja"
 ): string | undefined {
-  if (path === undefined || !path.includes(`/.pico-sdk/${tool}`)) {
+  if (path === undefined || !isManagedToolPath(path, tool)) {
     return undefined;
   }
 
@@ -42,6 +42,13 @@ export function selectedManagedToolVersion(
       : /\/\.pico-sdk\/ninja\/([v.0-9]+)\//;
 
   return regex.exec(path)?.[1];
+}
+
+export function isManagedToolPath(
+  path: string | undefined,
+  tool: "cmake" | "ninja"
+): boolean {
+  return path?.includes(`/.pico-sdk/${tool}`) ?? false;
 }
 
 export function resolveHomePath(path: string): string {
@@ -68,8 +75,21 @@ export async function ensureManagedTool(
     tool === "cmake" ? SettingsKey.cmakePath : SettingsKey.ninjaPath;
   const configuredPath = settings.getString(settingKey);
   const version = selectedManagedToolVersion(configuredPath, tool);
-  if (configuredPath === undefined || version === undefined) {
+  if (
+    configuredPath === undefined ||
+    !isManagedToolPath(configuredPath, tool)
+  ) {
     return true;
+  }
+
+  if (version === undefined) {
+    Logger.error(
+      LoggerSource.extension,
+      `Failed to get ${tool === "cmake" ? "CMake" : "Ninja"} version ` +
+        "from path in the settings."
+    );
+
+    return false;
   }
 
   if (existsSync(ensureExe(configuredPath.replace(HOME_VAR, homedir())))) {

--- a/src/projectVariants/index.mts
+++ b/src/projectVariants/index.mts
@@ -13,6 +13,7 @@ export function createProjectVariantRegistry(): DefaultProjectVariantRegistry {
 
 export type {
   PicoProjectVariant,
+  ProjectDetectionResult,
   ProjectSelections,
   ProjectVariantId,
 } from "./types.mjs";

--- a/src/projectVariants/index.mts
+++ b/src/projectVariants/index.mts
@@ -3,12 +3,18 @@ import { DefaultProjectVariantRegistry } from "./registry.mjs";
 import { RustProjectVariant } from "./rustVariant.mjs";
 import { ZephyrProjectVariant } from "./zephyrVariant.mjs";
 
+const projectVariantRegistry = new DefaultProjectVariantRegistry([
+  new RustProjectVariant(),
+  new ZephyrProjectVariant(),
+  new CCppProjectVariant(),
+]);
+
+export function getProjectVariantRegistry(): DefaultProjectVariantRegistry {
+  return projectVariantRegistry;
+}
+
 export function createProjectVariantRegistry(): DefaultProjectVariantRegistry {
-  return new DefaultProjectVariantRegistry([
-    new RustProjectVariant(),
-    new ZephyrProjectVariant(),
-    new CCppProjectVariant(),
-  ]);
+  return getProjectVariantRegistry();
 }
 
 export type {

--- a/src/projectVariants/index.mts
+++ b/src/projectVariants/index.mts
@@ -1,0 +1,18 @@
+import { CCppProjectVariant } from "./cCppVariant.mjs";
+import { DefaultProjectVariantRegistry } from "./registry.mjs";
+import { RustProjectVariant } from "./rustVariant.mjs";
+import { ZephyrProjectVariant } from "./zephyrVariant.mjs";
+
+export function createProjectVariantRegistry(): DefaultProjectVariantRegistry {
+  return new DefaultProjectVariantRegistry([
+    new RustProjectVariant(),
+    new ZephyrProjectVariant(),
+    new CCppProjectVariant(),
+  ]);
+}
+
+export type {
+  PicoProjectVariant,
+  ProjectSelections,
+  ProjectVariantId,
+} from "./types.mjs";

--- a/src/projectVariants/registry.mts
+++ b/src/projectVariants/registry.mts
@@ -7,6 +7,8 @@ import type {
 } from "./types.mjs";
 
 export class DefaultProjectVariantRegistry implements ProjectVariantRegistry {
+  private readonly detectedVariants = new Map<string, ProjectVariantId>();
+
   public constructor(private readonly variants: PicoProjectVariant[]) {}
 
   public async detect(
@@ -48,8 +50,19 @@ export class DefaultProjectVariantRegistry implements ProjectVariantRegistry {
   public async getActive(
     folder: WorkspaceFolder
   ): Promise<PicoProjectVariant | undefined> {
-    const result = await this.detect(folder);
+    const folderUri = folder.uri.toString();
+    const detectedVariant = this.detectedVariants.get(folderUri);
+    if (detectedVariant !== undefined) {
+      return this.get(detectedVariant);
+    }
 
-    return result.kind === "supported" ? this.get(result.variant) : undefined;
+    const result = await this.detect(folder);
+    if (result.kind === "supported") {
+      this.detectedVariants.set(folderUri, result.variant);
+
+      return this.get(result.variant);
+    }
+
+    return undefined;
   }
 }

--- a/src/projectVariants/registry.mts
+++ b/src/projectVariants/registry.mts
@@ -1,0 +1,50 @@
+import type { WorkspaceFolder } from "vscode";
+import type {
+  PicoProjectVariant,
+  ProjectDetectionResult,
+  ProjectVariantId,
+  ProjectVariantRegistry,
+} from "./types.mjs";
+
+export class DefaultProjectVariantRegistry implements ProjectVariantRegistry {
+  public constructor(private readonly variants: PicoProjectVariant[]) {}
+
+  public async detect(
+    folder: WorkspaceFolder
+  ): Promise<ProjectDetectionResult> {
+    let firstUnsupported: ProjectDetectionResult | undefined;
+
+    for (const variant of this.variants) {
+      const result = await variant.detect(folder);
+      if (result.kind === "supported") {
+        return result;
+      }
+
+      firstUnsupported ??= result;
+    }
+
+    return (
+      firstUnsupported ?? {
+        kind: "unsupported",
+        reason: "No supported Pico project markers were found.",
+      }
+    );
+  }
+
+  public get(id: ProjectVariantId): PicoProjectVariant {
+    const variant = this.variants.find(candidate => candidate.id === id);
+    if (variant === undefined) {
+      throw new Error(`Project variant is not registered: ${id}`);
+    }
+
+    return variant;
+  }
+
+  public async getActive(
+    folder: WorkspaceFolder
+  ): Promise<PicoProjectVariant | undefined> {
+    const result = await this.detect(folder);
+
+    return result.kind === "supported" ? this.get(result.variant) : undefined;
+  }
+}

--- a/src/projectVariants/registry.mts
+++ b/src/projectVariants/registry.mts
@@ -12,7 +12,8 @@ export class DefaultProjectVariantRegistry implements ProjectVariantRegistry {
   public async detect(
     folder: WorkspaceFolder
   ): Promise<ProjectDetectionResult> {
-    let firstUnsupported: ProjectDetectionResult | undefined;
+    let fallbackUnsupported: ProjectDetectionResult | undefined;
+    let importCandidate: ProjectDetectionResult | undefined;
 
     for (const variant of this.variants) {
       const result = await variant.detect(folder);
@@ -20,11 +21,15 @@ export class DefaultProjectVariantRegistry implements ProjectVariantRegistry {
         return result;
       }
 
-      firstUnsupported ??= result;
+      fallbackUnsupported = result;
+      if (result.offerImport) {
+        importCandidate = result;
+      }
     }
 
     return (
-      firstUnsupported ?? {
+      importCandidate ??
+      fallbackUnsupported ?? {
         kind: "unsupported",
         reason: "No supported Pico project markers were found.",
       }

--- a/src/projectVariants/rustVariant.mts
+++ b/src/projectVariants/rustVariant.mts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { ProgressLocation, window, type WorkspaceFolder } from "vscode";
 import Logger, { LoggerSource } from "../logger.mjs";
 import VersionBundlesLoader from "../utils/versionBundles.mjs";
+import { getSupportedToolchains } from "../utils/toolchainUtil.mjs";
 import {
   downloadAndInstallRust,
   installLatestRustRequirements,
@@ -18,7 +19,7 @@ import type {
   ProjectSelections,
   UpdateProjectUiInput,
 } from "./types.mjs";
-import { ensurePicoSdkInstalled } from "./common.mjs";
+import { ensureBasePicoDependencies } from "./common.mjs";
 
 export class RustProjectVariant implements PicoProjectVariant {
   public readonly id = "rust";
@@ -67,6 +68,36 @@ export class RustProjectVariant implements PicoProjectVariant {
     }
 
     input.selections.sdkVersion = latestSDK;
+    const latest = await vb.getLatest();
+    if (latest === undefined) {
+      void window.showErrorMessage(
+        "Failed to get latest version bundles. " +
+          "Please try again and check your settings."
+      );
+
+      return false;
+    }
+
+    const supportedToolchains = await getSupportedToolchains(
+      input.context.extensionUri
+    );
+    const toolchainVersion = input.selections.target?.includes("riscv")
+      ? latest[1].riscvToolchain
+      : latest[1].toolchain;
+    if (
+      supportedToolchains.find(
+        toolchain => toolchain.version === toolchainVersion
+      ) === undefined
+    ) {
+      void window.showErrorMessage(
+        "Failed to get default toolchain. " +
+          "Please try again and check your internet connection."
+      );
+
+      return false;
+    }
+    input.selections.toolchainVersion = toolchainVersion;
+    input.selections.picotoolVersion = latest[1].picotool;
 
     const python3Path = await findPython();
     if (!python3Path) {
@@ -79,9 +110,9 @@ export class RustProjectVariant implements PicoProjectVariant {
       return false;
     }
 
-    const sdk = await ensurePicoSdkInstalled({
+    const baseDependenciesInstalled = await ensureBasePicoDependencies({
       extensionUri: input.context.extensionUri,
-      sdkVersion: latestSDK,
+      selections: input.selections,
       python3Path: python3Path.replace(
         HOME_VAR,
         homedir().replaceAll("\\", "/")
@@ -90,11 +121,12 @@ export class RustProjectVariant implements PicoProjectVariant {
         "Downloading and installing latest Pico SDK (" +
         latestSDK +
         "). This may take a while...",
-      failureMessage: "Failed to install latest SDK version for rust project.",
-      logFailurePrefix: "Failed to install latest SDK",
-      logSuccessPrefix: "Found/installed latest SDK",
+      sdkFailureMessage:
+        "Failed to install latest SDK version for rust project.",
+      sdkLogFailurePrefix: "Failed to install latest SDK",
+      sdkLogSuccessPrefix: "Found/installed latest SDK",
     });
-    if (!sdk) {
+    if (!baseDependenciesInstalled) {
       return false;
     }
 

--- a/src/projectVariants/rustVariant.mts
+++ b/src/projectVariants/rustVariant.mts
@@ -1,0 +1,135 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { ProgressLocation, window, type WorkspaceFolder } from "vscode";
+import Logger, { LoggerSource } from "../logger.mjs";
+import VersionBundlesLoader from "../utils/versionBundles.mjs";
+import {
+  downloadAndInstallRust,
+  installLatestRustRequirements,
+  rustProjectGetSelectedChip,
+} from "../utils/rustUtil.mjs";
+import { downloadAndInstallSDK } from "../utils/download.mjs";
+import { SDK_REPOSITORY_URL } from "../utils/sharedConstants.mjs";
+import type {
+  EnsureDependenciesInput,
+  PicoProjectVariant,
+  ProjectDetectionResult,
+  ProjectSelections,
+  UpdateProjectUiInput,
+} from "./types.mjs";
+
+export class RustProjectVariant implements PicoProjectVariant {
+  public readonly id = "rust";
+  public readonly context = {
+    isPicoProject: true,
+    isRustProject: true,
+    isZephyrProject: false,
+  };
+
+  public detect(folder: WorkspaceFolder): ProjectDetectionResult {
+    if (existsSync(join(folder.uri.fsPath, ".pico-rs"))) {
+      return { kind: "supported", variant: this.id };
+    }
+
+    return {
+      kind: "unsupported",
+      reason: "No .pico-rs marker file was found.",
+    };
+  }
+
+  public readSelections(folder: WorkspaceFolder): ProjectSelections {
+    const chip = rustProjectGetSelectedChip(folder.uri.fsPath);
+
+    return {
+      chip: chip ?? undefined,
+      target: chip ?? undefined,
+      boardLabel: chip !== null ? chip.toUpperCase() : "N/A",
+    };
+  }
+
+  public async ensureDependencies(
+    input: EnsureDependenciesInput
+  ): Promise<boolean> {
+    const vb = new VersionBundlesLoader(input.context.extensionUri);
+    const latestSDK = await vb.getLatestSDK();
+    if (!latestSDK) {
+      Logger.error(
+        LoggerSource.extension,
+        "Failed to get latest Pico SDK version for Rust project."
+      );
+      void window.showErrorMessage(
+        "Failed to get latest Pico SDK version for Rust project."
+      );
+
+      return false;
+    }
+
+    input.selections.sdkVersion = latestSDK;
+
+    const sdk = await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title:
+          "Downloading and installing latest Pico SDK (" +
+          latestSDK +
+          "). This may take a while...",
+        cancellable: false,
+      },
+      async progress => {
+        const result = await downloadAndInstallSDK(
+          input.context.extensionUri,
+          latestSDK,
+          SDK_REPOSITORY_URL
+        );
+
+        progress.report({ increment: 100 });
+
+        if (!result) {
+          Logger.error(
+            LoggerSource.extension,
+            "Failed to install latest SDK",
+            `version: ${latestSDK}.`,
+            "Make sure all requirements are met."
+          );
+          void window.showErrorMessage(
+            "Failed to install latest SDK version for rust project."
+          );
+
+          return false;
+        }
+
+        Logger.info(
+          LoggerSource.extension,
+          "Found/installed latest SDK",
+          `version: ${latestSDK}`
+        );
+
+        return true;
+      }
+    );
+    if (!sdk) {
+      return false;
+    }
+
+    const cargo = await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: "Downloading and installing Rust. This may take a while...",
+        cancellable: false,
+      },
+      async () => downloadAndInstallRust()
+    );
+    if (!cargo) {
+      void window.showErrorMessage("Failed to install Rust.");
+
+      return false;
+    }
+
+    return installLatestRustRequirements(input.context.extensionUri);
+  }
+
+  public updateUi(input: UpdateProjectUiInput): void {
+    input.ui.showStatusBarItems(true);
+    input.ui.updateBoard(input.selections.boardLabel ?? "N/A");
+  }
+}

--- a/src/projectVariants/rustVariant.mts
+++ b/src/projectVariants/rustVariant.mts
@@ -8,8 +8,9 @@ import {
   installLatestRustRequirements,
   rustProjectGetSelectedChip,
 } from "../utils/rustUtil.mjs";
-import { downloadAndInstallSDK } from "../utils/download.mjs";
-import { SDK_REPOSITORY_URL } from "../utils/sharedConstants.mjs";
+import findPython, { showPythonNotFoundError } from "../utils/pythonHelper.mjs";
+import { HOME_VAR } from "../settings.mjs";
+import { homedir } from "os";
 import type {
   EnsureDependenciesInput,
   PicoProjectVariant,
@@ -17,6 +18,7 @@ import type {
   ProjectSelections,
   UpdateProjectUiInput,
 } from "./types.mjs";
+import { ensurePicoSdkInstalled } from "./common.mjs";
 
 export class RustProjectVariant implements PicoProjectVariant {
   public readonly id = "rust";
@@ -66,47 +68,32 @@ export class RustProjectVariant implements PicoProjectVariant {
 
     input.selections.sdkVersion = latestSDK;
 
-    const sdk = await window.withProgress(
-      {
-        location: ProgressLocation.Notification,
-        title:
-          "Downloading and installing latest Pico SDK (" +
-          latestSDK +
-          "). This may take a while...",
-        cancellable: false,
-      },
-      async progress => {
-        const result = await downloadAndInstallSDK(
-          input.context.extensionUri,
-          latestSDK,
-          SDK_REPOSITORY_URL
-        );
+    const python3Path = await findPython();
+    if (!python3Path) {
+      Logger.error(
+        LoggerSource.downloader,
+        "Failed to find Python3 executable."
+      );
+      showPythonNotFoundError();
 
-        progress.report({ increment: 100 });
+      return false;
+    }
 
-        if (!result) {
-          Logger.error(
-            LoggerSource.extension,
-            "Failed to install latest SDK",
-            `version: ${latestSDK}.`,
-            "Make sure all requirements are met."
-          );
-          void window.showErrorMessage(
-            "Failed to install latest SDK version for rust project."
-          );
-
-          return false;
-        }
-
-        Logger.info(
-          LoggerSource.extension,
-          "Found/installed latest SDK",
-          `version: ${latestSDK}`
-        );
-
-        return true;
-      }
-    );
+    const sdk = await ensurePicoSdkInstalled({
+      extensionUri: input.context.extensionUri,
+      sdkVersion: latestSDK,
+      python3Path: python3Path.replace(
+        HOME_VAR,
+        homedir().replaceAll("\\", "/")
+      ),
+      title:
+        "Downloading and installing latest Pico SDK (" +
+        latestSDK +
+        "). This may take a while...",
+      failureMessage: "Failed to install latest SDK version for rust project.",
+      logFailurePrefix: "Failed to install latest SDK",
+      logSuccessPrefix: "Found/installed latest SDK",
+    });
     if (!sdk) {
       return false;
     }
@@ -125,7 +112,9 @@ export class RustProjectVariant implements PicoProjectVariant {
       return false;
     }
 
-    return installLatestRustRequirements(input.context.extensionUri);
+    return installLatestRustRequirements(input.context.extensionUri, {
+      skipSdk: true,
+    });
   }
 
   public updateUi(input: UpdateProjectUiInput): void {

--- a/src/projectVariants/rustVariant.mts
+++ b/src/projectVariants/rustVariant.mts
@@ -19,7 +19,7 @@ import type {
   ProjectSelections,
   UpdateProjectUiInput,
 } from "./types.mjs";
-import { ensureBasePicoDependencies } from "./common.mjs";
+import { ensureBasePicoDependencies } from "../utils/picoDependencies.mjs";
 
 export class RustProjectVariant implements PicoProjectVariant {
   public readonly id = "rust";

--- a/src/projectVariants/selectionHelpers.mts
+++ b/src/projectVariants/selectionHelpers.mts
@@ -4,7 +4,7 @@ import Settings, { SettingsKey } from "../settings.mjs";
 import { cmakeGetPicoVar } from "../utils/cmakeUtil.mjs";
 import VersionBundlesLoader from "../utils/versionBundles.mjs";
 import { getSupportedToolchains } from "../utils/toolchainUtil.mjs";
-import { createProjectVariantRegistry } from "./index.mjs";
+import { getProjectVariantRegistry } from "./index.mjs";
 import type {
   PicoProjectVariant,
   ProjectSelections,
@@ -13,7 +13,7 @@ import type {
 export async function getActiveProjectVariant(
   folder: WorkspaceFolder
 ): Promise<PicoProjectVariant | undefined> {
-  return createProjectVariantRegistry().getActive(folder);
+  return getProjectVariantRegistry().getActive(folder);
 }
 
 export async function getActiveProjectSelections(

--- a/src/projectVariants/selectionHelpers.mts
+++ b/src/projectVariants/selectionHelpers.mts
@@ -1,0 +1,183 @@
+import { join } from "path";
+import { commands, type Uri, type WorkspaceFolder } from "vscode";
+import Settings, { SettingsKey } from "../settings.mjs";
+import { cmakeGetPicoVar } from "../utils/cmakeUtil.mjs";
+import VersionBundlesLoader from "../utils/versionBundles.mjs";
+import { getSupportedToolchains } from "../utils/toolchainUtil.mjs";
+import { createProjectVariantRegistry } from "./index.mjs";
+import type {
+  PicoProjectVariant,
+  ProjectSelections,
+} from "./types.mjs";
+
+export async function getActiveProjectVariant(
+  folder: WorkspaceFolder
+): Promise<PicoProjectVariant | undefined> {
+  return createProjectVariantRegistry().getActive(folder);
+}
+
+export async function getActiveProjectSelections(
+  folder: WorkspaceFolder
+): Promise<ProjectSelections | undefined> {
+  const variant = await getActiveProjectVariant(folder);
+  const selections = await variant?.readSelections(folder);
+
+  return selections ?? undefined;
+}
+
+export async function getActiveProjectChip(
+  folder: WorkspaceFolder
+): Promise<"rp2040" | "rp2350" | "rp235x" | undefined> {
+  const variant = await getActiveProjectVariant(folder);
+  if (variant === undefined) {
+    return undefined;
+  }
+
+  if (variant.id === "c-cpp") {
+    const platform = await getCmakeProjectPlatform(folder);
+
+    return platform === "rp2350-arm-s" || platform === "rp2350-riscv"
+      ? "rp2350"
+      : "rp2040";
+  }
+
+  const selections = await variant.readSelections(folder);
+  if (selections === null) {
+    return undefined;
+  }
+
+  if (variant.id === "rust") {
+    return selections.chip === "rp2350" || selections.chip === "rp2350-riscv"
+      ? "rp235x"
+      : selections.chip;
+  }
+
+  return selections.chip === "rp2350-riscv" ? "rp2350" : selections.chip;
+}
+
+export async function getActiveProjectTarget(
+  folder: WorkspaceFolder
+): Promise<"rp2040" | "rp2350" | "rp2350-riscv" | undefined> {
+  const variant = await getActiveProjectVariant(folder);
+  if (variant === undefined) {
+    return undefined;
+  }
+
+  if (variant.id === "c-cpp") {
+    const platform = await getCmakeProjectPlatform(folder);
+    if (platform === "rp2350-arm-s") {
+      return "rp2350";
+    } else if (platform === "rp2350-riscv") {
+      return "rp2350-riscv";
+    }
+
+    return "rp2040";
+  }
+
+  const selections = await variant.readSelections(folder);
+  if (selections === null) {
+    return undefined;
+  }
+
+  return selections.target;
+}
+
+export async function getActiveProjectToolchainVersion(
+  folder: WorkspaceFolder,
+  extensionUri?: Uri
+): Promise<string | undefined> {
+  const variant = await getActiveProjectVariant(folder);
+  if (variant === undefined) {
+    return undefined;
+  }
+
+  if (variant.id === "rust") {
+    if (extensionUri === undefined) {
+      return undefined;
+    }
+
+    const vbl = new VersionBundlesLoader(extensionUri);
+    const latestVb = await vbl.getLatest();
+    if (latestVb === undefined) {
+      return undefined;
+    }
+
+    const selections = await variant.readSelections(folder);
+    const useRiscv = selections?.chip?.includes("riscv") ?? false;
+
+    return useRiscv ? latestVb[1].riscvToolchain : latestVb[1].toolchain;
+  }
+
+  const selections = await variant.readSelections(folder);
+
+  return selections?.toolchainVersion;
+}
+
+export async function getActiveProjectSdkVersion(
+  folder: WorkspaceFolder,
+  extensionUri: Uri
+): Promise<string | undefined> {
+  const variant = await getActiveProjectVariant(folder);
+  if (variant === undefined) {
+    return undefined;
+  }
+
+  if (variant.id === "rust") {
+    return new VersionBundlesLoader(extensionUri).getLatestSDK();
+  }
+
+  const selections = await variant.readSelections(folder);
+
+  return selections?.sdkVersion;
+}
+
+export async function getActiveProjectSupportedToolchain(
+  folder: WorkspaceFolder,
+  extensionUri: Uri
+): Promise<string | undefined> {
+  const toolchainVersion = await getActiveProjectToolchainVersion(
+    folder,
+    extensionUri
+  );
+  if (toolchainVersion === undefined) {
+    return undefined;
+  }
+
+  const supportedToolchains = await getSupportedToolchains(extensionUri);
+  const supportedToolchain = supportedToolchains.find(
+    toolchain => toolchain.version === toolchainVersion
+  );
+
+  return supportedToolchain?.version;
+}
+
+export function toolchainTriple(toolchainVersion: string): string {
+  if (toolchainVersion.includes("RISCV")) {
+    return toolchainVersion.includes("COREV")
+      ? "riscv32-corev-elf"
+      : "riscv32-unknown-elf";
+  }
+
+  return "arm-none-eabi";
+}
+
+async function getCmakeProjectPlatform(
+  folder: WorkspaceFolder
+): Promise<string | null> {
+  const settings = Settings.getInstance();
+  let buildDir = join(folder.uri.fsPath, "build");
+  if (
+    settings !== undefined &&
+    settings.getBoolean(SettingsKey.useCmakeTools)
+  ) {
+    const cmakeBuildDir: string = await commands.executeCommand(
+      "cmake.buildDirectory"
+    );
+
+    if (cmakeBuildDir) {
+      buildDir = cmakeBuildDir;
+    }
+  }
+
+  return cmakeGetPicoVar(join(buildDir, "CMakeCache.txt"), "PICO_PLATFORM");
+}

--- a/src/projectVariants/types.mts
+++ b/src/projectVariants/types.mts
@@ -1,0 +1,73 @@
+import type { ExtensionContext, Uri, WorkspaceFolder } from "vscode";
+import type Settings from "../settings.mjs";
+import type UI from "../ui.mjs";
+
+export type ProjectVariantId = "c-cpp" | "rust" | "zephyr";
+
+export interface ProjectContextFlags {
+  isPicoProject: boolean;
+  isRustProject: boolean;
+  isZephyrProject: boolean;
+}
+
+export interface ProjectSelections {
+  sdkVersion?: string;
+  toolchainVersion?: string;
+  picotoolVersion?: string;
+  boardId?: string;
+  boardLabel?: string;
+  chip?: "rp2040" | "rp2350" | "rp2350-riscv" | "rp235x";
+  target?: "rp2040" | "rp2350" | "rp2350-riscv";
+}
+
+export type ProjectDetectionResult =
+  | { kind: "supported"; variant: ProjectVariantId }
+  | { kind: "unsupported"; reason: string; offerImport?: boolean };
+
+export interface ProjectVariantInput {
+  context: ExtensionContext;
+  settings: Settings;
+}
+
+export interface EnsureDependenciesInput extends ProjectVariantInput {
+  folder: WorkspaceFolder;
+  selections: ProjectSelections;
+}
+
+export interface UpdateProjectUiInput {
+  ui: UI;
+  selections: ProjectSelections;
+}
+
+export interface AfterActivationInput extends ProjectVariantInput {
+  folder: WorkspaceFolder;
+  selections: ProjectSelections;
+  ui: UI;
+}
+
+export interface PicoProjectVariant {
+  readonly id: ProjectVariantId;
+  readonly context: ProjectContextFlags;
+
+  detect(
+    folder: WorkspaceFolder
+  ): ProjectDetectionResult | Promise<ProjectDetectionResult>;
+  readSelections(
+    folder: WorkspaceFolder
+  ): ProjectSelections | null | Promise<ProjectSelections | null>;
+  ensureDependencies(
+    input: EnsureDependenciesInput
+  ): boolean | Promise<boolean>;
+  updateUi(input: UpdateProjectUiInput): void | Promise<void>;
+  afterActivation?(input: AfterActivationInput): boolean | Promise<boolean>;
+}
+
+export interface ProjectVariantRegistry {
+  detect(folder: WorkspaceFolder): Promise<ProjectDetectionResult>;
+  get(id: ProjectVariantId): PicoProjectVariant;
+  getActive(folder: WorkspaceFolder): Promise<PicoProjectVariant | undefined>;
+}
+
+export function projectRootUri(folder: WorkspaceFolder): Uri {
+  return folder.uri;
+}

--- a/src/projectVariants/zephyrVariant.mts
+++ b/src/projectVariants/zephyrVariant.mts
@@ -36,7 +36,11 @@ import type {
   UpdateProjectUiInput,
 } from "./types.mjs";
 import { cmakeSetupAutoConfigure } from "./cmakeActivation.mjs";
-import { resolveHomePath, selectedManagedToolVersion } from "./common.mjs";
+import {
+  isManagedToolPath,
+  resolveHomePath,
+  selectedManagedToolVersion,
+} from "./common.mjs";
 
 export class ZephyrProjectVariant implements PicoProjectVariant {
   public readonly id = "zephyr";
@@ -118,6 +122,15 @@ export class ZephyrProjectVariant implements PicoProjectVariant {
     }
 
     const cmakeVersion = selectedManagedToolVersion(cmakePath, "cmake") ?? "";
+    if (isManagedToolPath(cmakePath, "cmake") && cmakeVersion === "") {
+      Logger.error(
+        LoggerSource.extension,
+        "Failed to get CMake version from path in the settings."
+      );
+
+      return false;
+    }
+
     const ninjaPath = input.settings.getString(SettingsKey.ninjaPath);
     if (ninjaPath === undefined) {
       Logger.error(
@@ -131,6 +144,14 @@ export class ZephyrProjectVariant implements PicoProjectVariant {
       return false;
     }
     const ninjaVersion = selectedManagedToolVersion(ninjaPath, "ninja") ?? "";
+    if (isManagedToolPath(ninjaPath, "ninja") && ninjaVersion === "") {
+      Logger.error(
+        LoggerSource.extension,
+        "Failed to get Ninja version from path in the settings."
+      );
+
+      return false;
+    }
 
     const pinnedVersion = input.settings.getString(SettingsKey.zephyrVersion);
     if (pinnedVersion !== undefined && pinnedVersion.length > 0) {

--- a/src/projectVariants/zephyrVariant.mts
+++ b/src/projectVariants/zephyrVariant.mts
@@ -1,0 +1,345 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import {
+  FileSystemError,
+  Uri,
+  window,
+  workspace,
+  type WorkspaceFolder,
+} from "vscode";
+import Logger, { LoggerSource } from "../logger.mjs";
+import { SettingsKey } from "../settings.mjs";
+import type Settings from "../settings.mjs";
+import VersionBundlesLoader from "../utils/versionBundles.mjs";
+import { unknownErrorToString } from "../utils/errorHelper.mjs";
+import { CMAKELISTS_ZEPHYR_REGEX } from "../utils/sharedConstants.mjs";
+import {
+  getBoardFromZephyrProject,
+  getZephyrVersion,
+  setupZephyr,
+  updateZephyrCompilerPath,
+  updateZephyrVersion,
+  zephyrVerifyCMakeCache,
+} from "../utils/setupZephyr.mjs";
+import {
+  ZEPHYR_PICO,
+  ZEPHYR_PICO2,
+  ZEPHYR_PICO2_W,
+  ZEPHYR_PICO_W,
+} from "../models/zephyrBoards.mjs";
+import type {
+  AfterActivationInput,
+  EnsureDependenciesInput,
+  PicoProjectVariant,
+  ProjectDetectionResult,
+  ProjectSelections,
+  UpdateProjectUiInput,
+} from "./types.mjs";
+import { cmakeSetupAutoConfigure } from "./cmakeActivation.mjs";
+import { resolveHomePath, selectedManagedToolVersion } from "./common.mjs";
+
+export class ZephyrProjectVariant implements PicoProjectVariant {
+  public readonly id = "zephyr";
+  public readonly context = {
+    isPicoProject: true,
+    isRustProject: false,
+    isZephyrProject: true,
+  };
+
+  public async detect(
+    folder: WorkspaceFolder
+  ): Promise<ProjectDetectionResult> {
+    const cmakeListsFilePath = join(folder.uri.fsPath, "CMakeLists.txt");
+    if (!existsSync(cmakeListsFilePath)) {
+      return {
+        kind: "unsupported",
+        reason: "No CMakeLists.txt in workspace folder has been found.",
+      };
+    }
+
+    const cmakeListsContents = new TextDecoder().decode(
+      await workspace.fs.readFile(Uri.file(cmakeListsFilePath))
+    );
+    if (cmakeListsContents.trimStart().match(CMAKELISTS_ZEPHYR_REGEX)) {
+      return { kind: "supported", variant: this.id };
+    }
+
+    return {
+      kind: "unsupported",
+      reason: "CMakeLists.txt does not match the Zephyr Pico project marker.",
+    };
+  }
+
+  public async readSelections(
+    folder: WorkspaceFolder
+  ): Promise<ProjectSelections> {
+    const board = await getBoardFromZephyrProject(
+      join(folder.uri.fsPath, ".vscode", "tasks.json")
+    );
+
+    return {
+      boardId: board,
+      boardLabel: board === undefined ? undefined : zephyrBoardLabel(board),
+      chip: zephyrBoardChip(board),
+      target: zephyrBoardTarget(board),
+    };
+  }
+
+  public async ensureDependencies(
+    input: EnsureDependenciesInput
+  ): Promise<boolean> {
+    Logger.info(LoggerSource.extension, "Project is of type: Zephyr");
+
+    const vb = new VersionBundlesLoader(input.context.extensionUri);
+    const latest = await vb.getLatest();
+    if (latest === undefined) {
+      Logger.error(
+        LoggerSource.extension,
+        "Failed to get latest version bundle for Zephyr project."
+      );
+      void window.showErrorMessage(
+        "Failed to get latest version bundle for Zephyr project."
+      );
+
+      return false;
+    }
+
+    const cmakePath = input.settings.getString(SettingsKey.cmakePath);
+    if (cmakePath === undefined) {
+      Logger.error(
+        LoggerSource.extension,
+        "CMake path not set in settings. Cannot setup Zephyr project."
+      );
+      void window.showErrorMessage(
+        "CMake path not set in settings. Cannot setup Zephyr project."
+      );
+
+      return false;
+    }
+
+    const cmakeVersion = selectedManagedToolVersion(cmakePath, "cmake") ?? "";
+    const ninjaPath = input.settings.getString(SettingsKey.ninjaPath);
+    if (ninjaPath === undefined) {
+      Logger.error(
+        LoggerSource.extension,
+        "Ninja path not set in settings. Cannot setup Zephyr project."
+      );
+      void window.showErrorMessage(
+        "Ninja path not set in settings. Cannot setup Zephyr project."
+      );
+
+      return false;
+    }
+    const ninjaVersion = selectedManagedToolVersion(ninjaPath, "ninja") ?? "";
+
+    const pinnedVersion = input.settings.getString(SettingsKey.zephyrVersion);
+    if (pinnedVersion !== undefined && pinnedVersion.length > 0) {
+      const switched = await ensurePinnedZephyrVersion(
+        input.settings,
+        pinnedVersion
+      );
+      if (!switched) {
+        return false;
+      }
+    }
+
+    const result = await setupZephyr({
+      extUri: input.context.extensionUri,
+      cmakeMode: cmakeVersion !== "" ? 2 : 3,
+      cmakePath: cmakeVersion !== "" ? "" : resolveHomePath(cmakePath),
+      cmakeVersion,
+      ninjaMode: ninjaVersion !== "" ? 2 : 3,
+      ninjaPath: ninjaVersion !== "" ? "" : resolveHomePath(ninjaPath),
+      ninjaVersion,
+    });
+    if (result === undefined) {
+      void window.showErrorMessage(
+        "Failed to setup Zephyr Toolchain. See logs for details."
+      );
+
+      return false;
+    }
+
+    void window.showInformationMessage(
+      "Zephyr Toolchain setup done. You can now build your project."
+    );
+
+    const selectedZephyrVersion = await getZephyrVersion();
+    if (selectedZephyrVersion === undefined) {
+      Logger.error(
+        LoggerSource.extension,
+        "Failed to get selected system Zephyr version. Defaulting to main."
+      );
+    }
+    input.selections.sdkVersion = selectedZephyrVersion ?? "main";
+
+    return true;
+  }
+
+  public updateUi(input: UpdateProjectUiInput): void {
+    input.ui.showStatusBarItems(false, true);
+    input.ui.updateSDKVersion(input.selections.sdkVersion ?? "main");
+    if (input.selections.boardLabel !== undefined) {
+      input.ui.updateBoard(input.selections.boardLabel);
+    }
+  }
+
+  public async afterActivation(input: AfterActivationInput): Promise<boolean> {
+    const selectedZephyrVersion = input.selections.sdkVersion ?? "main";
+    const cppCompilerUpdated = await updateZephyrCompilerPath(
+      input.folder.uri,
+      selectedZephyrVersion
+    );
+
+    if (!cppCompilerUpdated) {
+      void window.showErrorMessage(
+        "Failed to update C++ compiler path in c_cpp_properties.json"
+      );
+    }
+
+    await zephyrVerifyCMakeCache(input.folder.uri);
+
+    if (input.settings.getBoolean(SettingsKey.cmakeAutoConfigure)) {
+      await cmakeSetupAutoConfigure(input.folder, input.ui);
+    } else {
+      await warnIfZephyrBuildFolderIsEmpty(input.folder);
+    }
+
+    return true;
+  }
+}
+
+async function ensurePinnedZephyrVersion(
+  settings: Settings,
+  pinnedVersion: string
+): Promise<boolean> {
+  const systemVersion = await getZephyrVersion();
+  if (systemVersion === undefined) {
+    Logger.error(
+      LoggerSource.extension,
+      "Failed to get system Zephyr version."
+    );
+    void window.showErrorMessage(
+      "Failed to get system Zephyr version. Cannot setup Zephyr project."
+    );
+
+    return false;
+  }
+
+  if (systemVersion === pinnedVersion) {
+    return true;
+  }
+
+  const switchVersion = await window.showInformationMessage(
+    `Project Zephyr version (${pinnedVersion}) differs from system ` +
+      `version (${systemVersion}). ` +
+      "Do you want to switch the system version?",
+    { modal: true },
+    "Yes",
+    "No - Use system version",
+    "No - Pin to system version"
+  );
+
+  if (switchVersion === "Yes") {
+    const switchResult = await updateZephyrVersion(pinnedVersion);
+    if (!switchResult) {
+      void window.showErrorMessage(
+        `Failed to switch Zephyr version to ${pinnedVersion}. ` +
+          "Cannot setup Zephyr project."
+      );
+
+      return false;
+    }
+
+    void window.showInformationMessage(
+      `Switched Zephyr version to ${pinnedVersion}.`
+    );
+    Logger.info(
+      LoggerSource.extension,
+      `Switched Zephyr version to ${pinnedVersion}.`
+    );
+
+    return true;
+  }
+
+  if (switchVersion === "No - Pin to system version") {
+    await settings.update(SettingsKey.zephyrVersion, systemVersion);
+    void window.showInformationMessage(
+      `Pinned Zephyr version to ${systemVersion}.`
+    );
+    Logger.info(
+      LoggerSource.extension,
+      `Pinned Zephyr version to ${systemVersion}.`
+    );
+  }
+
+  return true;
+}
+
+async function warnIfZephyrBuildFolderIsEmpty(
+  folder: WorkspaceFolder
+): Promise<void> {
+  const buildUri = Uri.file(join(folder.uri.fsPath, "build"));
+  try {
+    await workspace.fs.stat(buildUri);
+    const buildDirContents = await workspace.fs.readDirectory(buildUri);
+
+    if (buildDirContents.length === 0) {
+      void window.showWarningMessage(
+        "To get full intellisense support please build the project once."
+      );
+    }
+  } catch (error) {
+    if (error instanceof FileSystemError && error.code === "FileNotFound") {
+      void window.showWarningMessage(
+        "To get full intellisense support please build the project once."
+      );
+
+      Logger.debug(
+        LoggerSource.extension,
+        'No "build" folder found. Intellisense might not work ' +
+          "properly until a build has been done."
+      );
+    } else {
+      Logger.error(
+        LoggerSource.extension,
+        "Error when reading build folder:",
+        unknownErrorToString(error)
+      );
+    }
+  }
+}
+
+function zephyrBoardLabel(board: string): string {
+  if (board === ZEPHYR_PICO2_W) {
+    return "Pico 2W";
+  } else if (board === ZEPHYR_PICO2) {
+    return "Pico 2";
+  } else if (board === ZEPHYR_PICO_W) {
+    return "Pico W";
+  } else if (board === ZEPHYR_PICO) {
+    return "Pico";
+  }
+
+  return "Other";
+}
+
+function zephyrBoardChip(
+  board: string | undefined
+): "rp2040" | "rp2350" | undefined {
+  if (board === ZEPHYR_PICO || board === ZEPHYR_PICO_W) {
+    return "rp2040";
+  }
+
+  if (board === ZEPHYR_PICO2 || board === ZEPHYR_PICO2_W) {
+    return "rp2350";
+  }
+
+  return undefined;
+}
+
+function zephyrBoardTarget(
+  board: string | undefined
+): "rp2040" | "rp2350" | undefined {
+  return zephyrBoardChip(board);
+}

--- a/src/utils/picoDependencies.mts
+++ b/src/utils/picoDependencies.mts
@@ -1,0 +1,216 @@
+import { ProgressLocation, window, type Uri } from "vscode";
+import type { Progress as GotProgress } from "got";
+import Logger, { LoggerSource } from "../logger.mjs";
+import {
+  downloadAndInstallOpenOCD,
+  downloadAndInstallPicotool,
+  downloadAndInstallSDK,
+  downloadAndInstallToolchain,
+  downloadAndInstallTools,
+} from "./download.mjs";
+import {
+  OPENOCD_VERSION,
+  SDK_REPOSITORY_URL,
+} from "./sharedConstants.mjs";
+import { getSupportedToolchains } from "./toolchainUtil.mjs";
+
+export interface PicoDependencySelections {
+  sdkVersion?: string;
+  toolchainVersion?: string;
+  picotoolVersion?: string;
+}
+
+export async function ensureBasePicoDependencies(input: {
+  extensionUri: Uri;
+  selections: PicoDependencySelections;
+  title: string;
+  sdkFailureMessage: string;
+  sdkLogFailurePrefix: string;
+  sdkLogSuccessPrefix: string;
+  python3Path?: string;
+}): Promise<boolean> {
+  if (
+    input.selections.sdkVersion === undefined ||
+    input.selections.toolchainVersion === undefined ||
+    input.selections.picotoolVersion === undefined
+  ) {
+    return false;
+  }
+
+  const sdkInstalled = await ensurePicoSdkInstalled({
+    extensionUri: input.extensionUri,
+    sdkVersion: input.selections.sdkVersion,
+    python3Path: input.python3Path,
+    title: input.title,
+    failureMessage: input.sdkFailureMessage,
+    logFailurePrefix: input.sdkLogFailurePrefix,
+    logSuccessPrefix: input.sdkLogSuccessPrefix,
+  });
+  if (!sdkInstalled) {
+    return false;
+  }
+
+  const toolchains = await getSupportedToolchains(input.extensionUri);
+  const selectedToolchain = toolchains.find(
+    toolchain => toolchain.version === input.selections.toolchainVersion
+  );
+  if (selectedToolchain === undefined) {
+    Logger.error(
+      LoggerSource.extension,
+      "Failed to detect project toolchain version."
+    );
+    void window.showErrorMessage("Failed to detect project toolchain version.");
+
+    return false;
+  }
+
+  const toolchainInstalled = await withDownloadProgress(
+    "Downloading and installing toolchain as selected. " +
+      "This may take a while...",
+    progress => downloadAndInstallToolchain(selectedToolchain, progress)
+  );
+  if (!toolchainInstalled) {
+    Logger.error(
+      LoggerSource.extension,
+      "Failed to install project toolchain",
+      `version: ${input.selections.toolchainVersion}`
+    );
+    void window.showErrorMessage(
+      "Failed to install project toolchain version."
+    );
+
+    return false;
+  }
+  Logger.info(
+    LoggerSource.extension,
+    "Found/installed project toolchain",
+    `version: ${input.selections.toolchainVersion}`
+  );
+
+  const toolsInstalled = await withDownloadProgress(
+    "Downloading and installing tools as selected. This may take a while...",
+    progress => downloadAndInstallTools(input.selections.sdkVersion!, progress)
+  );
+  if (!toolsInstalled) {
+    Logger.error(
+      LoggerSource.extension,
+      "Failed to install project SDK",
+      `version: ${input.selections.sdkVersion}.`,
+      "Make sure all requirements are met."
+    );
+    void window.showErrorMessage("Failed to install project SDK version.");
+
+    return false;
+  }
+  Logger.info(
+    LoggerSource.extension,
+    "Found/installed project SDK",
+    `version: ${input.selections.sdkVersion}`
+  );
+
+  const picotoolInstalled = await withDownloadProgress(
+    "Downloading and installing picotool as selected. " +
+      "This may take a while...",
+    progress =>
+      downloadAndInstallPicotool(input.selections.picotoolVersion!, progress)
+  );
+  if (!picotoolInstalled) {
+    Logger.error(LoggerSource.extension, "Failed to install picotool.");
+    void window.showErrorMessage("Failed to install picotool.");
+
+    return false;
+  }
+  Logger.debug(LoggerSource.extension, "Found/installed picotool.");
+
+  const openOcdInstalled = await withDownloadProgress(
+    "Downloading and installing OpenOCD. This may take a while...",
+    progress => downloadAndInstallOpenOCD(OPENOCD_VERSION, progress)
+  );
+  if (!openOcdInstalled) {
+    Logger.error(
+      LoggerSource.extension,
+      "Failed to download and install OpenOCD."
+    );
+    void window.showWarningMessage("Failed to download and install OpenOCD.");
+  } else {
+    Logger.debug(LoggerSource.extension, "Found/installed OpenOCD.");
+    void window.showInformationMessage("OpenOCD found/installed successfully.");
+  }
+
+  return true;
+}
+
+export async function ensurePicoSdkInstalled(input: {
+  extensionUri: Uri;
+  sdkVersion: string;
+  python3Path?: string;
+  title: string;
+  failureMessage: string;
+  logFailurePrefix: string;
+  logSuccessPrefix: string;
+}): Promise<boolean> {
+  const result = await window.withProgress(
+    {
+      location: ProgressLocation.Notification,
+      title: input.title,
+      cancellable: false,
+    },
+    async progress => {
+      const installResult = await downloadAndInstallSDK(
+        input.extensionUri,
+        input.sdkVersion,
+        SDK_REPOSITORY_URL,
+        input.python3Path
+      );
+
+      progress.report({ increment: 100 });
+
+      return installResult;
+    }
+  );
+
+  if (!result) {
+    Logger.error(
+      LoggerSource.extension,
+      input.logFailurePrefix,
+      `version: ${input.sdkVersion}.`,
+      "Make sure all requirements are met."
+    );
+    void window.showErrorMessage(input.failureMessage);
+
+    return false;
+  }
+
+  Logger.info(
+    LoggerSource.extension,
+    input.logSuccessPrefix,
+    `version: ${input.sdkVersion}`
+  );
+
+  return true;
+}
+
+export async function withDownloadProgress(
+  title: string,
+  action: (progress?: (progress: GotProgress) => void) => Promise<boolean>
+): Promise<boolean> {
+  let progressState = 0;
+
+  return window.withProgress(
+    {
+      location: ProgressLocation.Notification,
+      title,
+      cancellable: false,
+    },
+    async progress => {
+      const result = await action((prog: GotProgress) => {
+        const percent = prog.percent * 100;
+        progress.report({ increment: percent - progressState });
+        progressState = percent;
+      });
+      progress.report({ increment: 100 });
+
+      return result;
+    }
+  );
+}

--- a/src/utils/rustUtil.mts
+++ b/src/utils/rustUtil.mts
@@ -412,7 +412,8 @@ export function rustProjectGetSelectedChip(
  * @param extensionUri The URI of the extension
  */
 export async function installLatestRustRequirements(
-  extensionUri: Uri
+  extensionUri: Uri,
+  options: { skipSdk?: boolean } = {}
 ): Promise<boolean> {
   const vb = new VersionBundlesLoader(extensionUri);
   const latest = await vb.getLatest();
@@ -434,46 +435,49 @@ export async function installLatestRustRequirements(
     return false;
   }
 
-  let result = await window.withProgress(
-    {
-      location: ProgressLocation.Notification,
-      title: "Downloading and installing SDK",
-      cancellable: false,
-    },
-    async progress2 => {
-      const result = await downloadAndInstallSDK(
-        extensionUri,
-        latest[0],
-        SDK_REPOSITORY_URL,
-        // python3Path is only possible undefined if downloaded and
-        // there is already checked and returned if this happened
-        python3Path.replace(HOME_VAR, homedir().replaceAll("\\", "/"))
-      );
-
-      if (!result) {
-        Logger.error(
-          LoggerSource.downloader,
-          "Failed to download and install SDK."
-        );
-        progress2.report({
-          message: "Failed - Make sure all requirements are met.",
-          increment: 100,
-        });
-
-        void window.showErrorMessage(
-          "Failed to download and install SDK. " +
-            "Make sure all requirements are met."
+  let result = true;
+  if (!options.skipSdk) {
+    result = await window.withProgress(
+      {
+        location: ProgressLocation.Notification,
+        title: "Downloading and installing SDK",
+        cancellable: false,
+      },
+      async progress2 => {
+        const result = await downloadAndInstallSDK(
+          extensionUri,
+          latest[0],
+          SDK_REPOSITORY_URL,
+          // python3Path is only possible undefined if downloaded and
+          // there is already checked and returned if this happened
+          python3Path.replace(HOME_VAR, homedir().replaceAll("\\", "/"))
         );
 
-        return false;
+        if (!result) {
+          Logger.error(
+            LoggerSource.downloader,
+            "Failed to download and install SDK."
+          );
+          progress2.report({
+            message: "Failed - Make sure all requirements are met.",
+            increment: 100,
+          });
+
+          void window.showErrorMessage(
+            "Failed to download and install SDK. " +
+              "Make sure all requirements are met."
+          );
+
+          return false;
+        }
+
+        return true;
       }
+    );
 
-      return true;
+    if (!result) {
+      return false;
     }
-  );
-
-  if (!result) {
-    return false;
   }
 
   const supportedToolchains = await getSupportedToolchains(extensionUri);


### PR DESCRIPTION
Hello all, I'm working on a proposal to add Swift support to the VSCode extension. While working on that I realized there was an opportunity to make project activation and settings detection a bit more abstract, untangling some of the code in `extension.mts` while preserving functionality.

I opened the issue #259 to describe the problem, this PR is an implementation proposal. I hope the change size is manageable. I'd be happy to change the approach or break down the PR further if that would help readability.

I've been running a couple test cases and seems to preserve the existing behavior as expected. I verified:
- non-pico projects
- C/C++
- Rust
- Zephyr

Tests included, when applicable: setting board, chip, sdk version, configure CMake, proper handling of non-pico projects.

---

## Summary

This PR refactors project detection and activation around a small project-variant interface for the existing Pico project types: C/C++, Rust, and Zephyr.

The goal is not to change user-visible behavior. It is to make the current behavior easier to follow before adding another project type. Previously, activation mixed project detection, selected SDK/toolchain/board parsing, dependency setup, status bar updates, CMake setup, Rust setup, and Zephyr setup in one large flow. That made it difficult to see which parts were shared across project types and which parts were specific to one variant.

This change separates those responsibilities while keeping compatibility with the existing flows.

## What Changed

- Added a project variant registry and per-variant implementations for:
  - C/C++ Pico SDK projects
  - Rust Pico projects
  - Zephyr Pico projects

- Moved C/C++ activation behavior into `CCppProjectVariant`, including:
  - extension-created project detection
  - importable Pico-like project detection
  - selected SDK/toolchain/picotool/board parsing
  - baseline Pico dependency setup
  - managed CMake/Ninja checks
  - Python checks
  - CMake auto-configure / CMake Tools kit handling

- Moved shared Pico dependency setup into `utils/picoDependencies.mts` so SDK, toolchain, tools, picotool, and OpenOCD setup are not tied to only one project type.

- Kept Zephyr as a compatibility wrapper around the existing `setupZephyr` flow. This avoids changing the deeper Zephyr setup behavior in this PR while still making activation use the same project-variant structure.

- Updated path/helper commands to resolve chip, target, SDK, and toolchain information through project variant helpers instead of duplicating project-type checks in each command.

## Why

This prepares the extension for adding another project type without adding more special cases to activation and command handlers.

The main design idea is:

- project variants determine what kind of project is open
- variants know how to read that project’s selected SDK/toolchain/board/chip values
- common dependencies are installed from those resolved selections
- commands ask the active variant for project facts instead of re-detecting the project type themselves

That makes the relationship between old and new behavior clearer and gives future project types a defined place to plug in.

## Compatibility Notes

This PR intentionally preserves the existing behavior for supported project types:

- C/C++ projects still use the generated CMake metadata as the source of SDK/toolchain/picotool selections.
- Rust projects still use `.pico-rs` and the latest version bundle behavior.
- Zephyr projects still delegate setup to the existing `setupZephyr` implementation.
- Existing import prompt behavior is preserved for Pico-like CMake projects that contain `pico_sdk_init()` but are not extension-managed yet.
- Existing command behavior for `getChip`, `getTarget`, `getGDBPath`, compiler paths, SVD path, and Zephyr paths is retained.
