### PR TITLE
Zephyr fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You should continue using this extension for running & debugging, and we recomme
 
 Unfortunately, the Zephyr project requires numerous external dependencies. Most of these are covered automatically, but for `wget` we were not able to identify a reliable upstream source that provides official binaries for all three supported platforms.
 
-We recommend using package managers such as winget (Windows), Homebrew or MacPorts (macOS), or your system package manager on Linux to install `wget` or consult the [Zephyr documentation](https://docs.zephyrproject.org/latest/getting_started/index.html) for more information.
+We recommend using package managers such as winget (Windows), Homebrew or MacPorts (macOS), or your system package manager on Linux to install `wget` or consult the [Zephyr documentation](https://docs.zephyrproject.org/latest/develop/getting_started/index.html) for more information.
 
 For further context, see this discussion in the Zephyr project: https://github.com/zephyrproject-rtos/sdk-ng/pull/1016
 
@@ -109,10 +109,22 @@ For further context, see this discussion in the Zephyr project: https://github.c
 
 * **wget** - Required for sdk-ng to download toolchains.
 
+### Windows only
+
+* Must allow PowerShell script execution to activate the virtual environment - this can be done by running the following commands from an Administrator PowerShell:
+```
+Set-ExecutionPolicy RemoteSigned -Scope LocalMachine
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
 ### Linux and macOS only
 
 * **7-Zip** - Required for sdk-ng to extract toolchains. Install via your package manager (e.g., `brew install p7zip` on macOS or `sudo apt install p7zip-full` on Debian based Linux distributions) or download from [7-zip.org](https://www.7-zip.org/).
 * **python3-venv** - Required to create isolated Python environments. Install via your package manager (e.g., `sudo apt install python3-venv` on Debian based Linux distributions).
+
+#### Linux only
+
+* **\[Strongly Recommended\]** Python 3.12 - Zephyr states that using a newer Python release may fail on some systems, so strongly recommends using Python 3.12
 
 ## VS Code Profiles
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You should continue using this extension for running & debugging, and we recomme
 
 Unfortunately, the Zephyr project requires numerous external dependencies. Most of these are covered automatically, but for `wget` we were not able to identify a reliable upstream source that provides official binaries for all three supported platforms.
 
-We recommend using package managers such as winget (Windows), Homebrew or MacPorts (macOS), or your system package manager on Linux to install `wget` or consult the [Zephyr documentation](https://docs.zephyrproject.org/latest/getting_started/index.html) for more information.
+We recommend using package managers such as winget (Windows), Homebrew or MacPorts (macOS), or your system package manager on Linux to install `wget` or consult the [Zephyr documentation](https://docs.zephyrproject.org/latest/develop/getting_started/index.html) for more information.
 
 For further context, see this discussion in the Zephyr project: https://github.com/zephyrproject-rtos/sdk-ng/pull/1016
 
@@ -107,10 +107,22 @@ For further context, see this discussion in the Zephyr project: https://github.c
 
 * **wget** - Required for sdk-ng to download toolchains.
 
+### Windows only
+
+* Must allow PowerShell script execution to activate the virtual environment - this can be done by running the following commands from an Administrator PowerShell:
+```
+Set-ExecutionPolicy RemoteSigned -Scope LocalMachine
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
 ### Linux and macOS only
 
 * **7-Zip** - Required for sdk-ng to extract toolchains. Install via your package manager (e.g., `brew install p7zip` on macOS or `sudo apt install p7zip-full` on Debian based Linux distributions) or download from [7-zip.org](https://www.7-zip.org/).
 * **python3-venv** - Required to create isolated Python environments. Install via your package manager (e.g., `sudo apt install python3-venv` on Debian based Linux distributions).
+
+#### Linux only
+
+* **\[Strongly Recommended\]** Python 3.12 - Zephyr states that using a newer Python release may fail on some systems, so strongly recommends using Python 3.12
 
 ## VS Code Profiles
 

--- a/src/utils/cmakeUtil.mts
+++ b/src/utils/cmakeUtil.mts
@@ -279,7 +279,9 @@ export async function configureCmakeNinja(
             isZephyrProject ? zephyrCommand : command,
             {
               env: customEnv,
-              cwd: zephyrWorkspace || folder.fsPath,
+              cwd: isZephyrProject
+                ? zephyrWorkspace || folder.fsPath
+                : folder.fsPath,
               windowsHide: false,
             },
             error => {

--- a/src/utils/cmakeUtil.mts
+++ b/src/utils/cmakeUtil.mts
@@ -266,6 +266,11 @@ export async function configureCmakeNinja(
           for (const snippet of snippets) {
             zephyrCommand += ` -S ${snippet}`;
           }
+          if (snippets.length > 0) {
+            zephyrCommand +=
+              ` -- -DSNIPPET_ROOT=` +
+              `"${folder.fsPath.replaceAll("\\", "/")}"`;
+          }
         }
 
         await new Promise<void>((resolve, reject) => {
@@ -274,9 +279,7 @@ export async function configureCmakeNinja(
             isZephyrProject ? zephyrCommand : command,
             {
               env: customEnv,
-              cwd: isZephyrProject
-                ? zephyrWorkspace || folder.fsPath
-                : folder.fsPath,
+              cwd: zephyrWorkspace || folder.fsPath,
               windowsHide: false,
             },
             error => {

--- a/src/utils/download.mts
+++ b/src/utils/download.mts
@@ -43,8 +43,6 @@ import {
   HTTP_STATUS_UNAUTHORIZED,
   ownerOfRepository,
   repoNameOfRepository,
-  WINDOWS_ARM64_PYTHON_DOWNLOAD_URL,
-  WINDOWS_X86_PYTHON_DOWNLOAD_URL,
 } from "./sharedConstants.mjs";
 import { compareGe } from "./semverUtil.mjs";
 import LastUsedDepsStore from "./lastUsedDeps.mjs";
@@ -1270,7 +1268,8 @@ function _runCommand(
  * @returns
  */
 export async function downloadEmbedPython(
-  progressCallback?: (progress: Progress) => void
+  progressCallback?: (progress: Progress) => void,
+  version: string = CURRENT_PYTHON_VERSION
 ): Promise<string | undefined> {
   if (
     // even tough this function supports downloading python3 on macOS arm64
@@ -1287,9 +1286,9 @@ export async function downloadEmbedPython(
     return;
   }
 
-  const targetDirectory = buildPython3Path(CURRENT_PYTHON_VERSION);
+  const targetDirectory = buildPython3Path(version);
   const settingsTargetDirectory =
-    `${HOME_VAR}/.pico-sdk` + `/python/${CURRENT_PYTHON_VERSION}`;
+    `${HOME_VAR}/.pico-sdk` + `/python/${version}`;
 
   // Check if the Embed Python is already installed
   if (
@@ -1310,16 +1309,16 @@ export async function downloadEmbedPython(
   // select download url
   // process.platform === "darwin" ? versionBundle.python.macos : versionBundle.python.windowsAmd64;
   const downloadUrl = new URL(
-    process.arch === "arm64"
-      ? WINDOWS_ARM64_PYTHON_DOWNLOAD_URL
-      : WINDOWS_X86_PYTHON_DOWNLOAD_URL
+    `https://www.python.org/ftp/python/${version}/python-${version}-embed-${
+      process.arch === "arm64" ? "arm64" : "amd64"
+    }.zip`
   );
 
   const tmpBasePath = join(tmpdir(), "pico-sdk");
   await mkdir(tmpBasePath, { recursive: true });
   const archiveFilePath = join(
     tmpBasePath,
-    `python-${CURRENT_PYTHON_VERSION}.zip`
+    `python-${version}.zip`
   );
 
   const result = await downloadFileGot(
@@ -1429,7 +1428,7 @@ export async function downloadEmbedPython(
     await workspace.fs.createDirectory(Uri.file(dllDir));
 
     // Write to *._pth to allow use of installed packages
-    const versionAppend = CURRENT_PYTHON_VERSION.split(".")
+    const versionAppend = version.split(".")
       .slice(0, 2)
       .join("");
     const pthFile = `${targetDirectory}/python${versionAppend}._pth`;
@@ -1475,7 +1474,7 @@ export async function downloadEmbedPython(
 
   await LastUsedDepsStore.instance.record(
     "embedded-python",
-    CURRENT_PYTHON_VERSION
+    version
   );
 
   return pythonExe;

--- a/src/utils/download.mts
+++ b/src/utils/download.mts
@@ -43,8 +43,6 @@ import {
   HTTP_STATUS_UNAUTHORIZED,
   ownerOfRepository,
   repoNameOfRepository,
-  WINDOWS_ARM64_PYTHON_DOWNLOAD_URL,
-  WINDOWS_X86_PYTHON_DOWNLOAD_URL,
 } from "./sharedConstants.mjs";
 import { compareGe } from "./semverUtil.mjs";
 import LastUsedDepsStore from "./lastUsedDeps.mjs";
@@ -1257,7 +1255,8 @@ function _runCommand(
  * @returns
  */
 export async function downloadEmbedPython(
-  progressCallback?: (progress: Progress) => void
+  progressCallback?: (progress: Progress) => void,
+  version: string = CURRENT_PYTHON_VERSION
 ): Promise<string | undefined> {
   if (
     // even tough this function supports downloading python3 on macOS arm64
@@ -1274,9 +1273,9 @@ export async function downloadEmbedPython(
     return;
   }
 
-  const targetDirectory = buildPython3Path(CURRENT_PYTHON_VERSION);
+  const targetDirectory = buildPython3Path(version);
   const settingsTargetDirectory =
-    `${HOME_VAR}/.pico-sdk` + `/python/${CURRENT_PYTHON_VERSION}`;
+    `${HOME_VAR}/.pico-sdk` + `/python/${version}`;
 
   // Check if the Embed Python is already installed
   if (
@@ -1297,16 +1296,16 @@ export async function downloadEmbedPython(
   // select download url
   // process.platform === "darwin" ? versionBundle.python.macos : versionBundle.python.windowsAmd64;
   const downloadUrl = new URL(
-    process.arch === "arm64"
-      ? WINDOWS_ARM64_PYTHON_DOWNLOAD_URL
-      : WINDOWS_X86_PYTHON_DOWNLOAD_URL
+    `https://www.python.org/ftp/python/${version}/python-${version}-embed-${
+      process.arch === "arm64" ? "arm64" : "amd64"
+    }.zip`
   );
 
   const tmpBasePath = join(tmpdir(), "pico-sdk");
   await mkdir(tmpBasePath, { recursive: true });
   const archiveFilePath = join(
     tmpBasePath,
-    `python-${CURRENT_PYTHON_VERSION}.zip`
+    `python-${version}.zip`
   );
 
   const result = await downloadFileGot(
@@ -1416,7 +1415,7 @@ export async function downloadEmbedPython(
     await workspace.fs.createDirectory(Uri.file(dllDir));
 
     // Write to *._pth to allow use of installed packages
-    const versionAppend = CURRENT_PYTHON_VERSION.split(".")
+    const versionAppend = version.split(".")
       .slice(0, 2)
       .join("");
     const pthFile = `${targetDirectory}/python${versionAppend}._pth`;
@@ -1461,7 +1460,7 @@ export async function downloadEmbedPython(
 
   await LastUsedDepsStore.instance.record(
     "embedded-python",
-    CURRENT_PYTHON_VERSION
+    version
   );
 
   return pythonExe;

--- a/src/utils/projectGeneration/projectZephyr.mts
+++ b/src/utils/projectGeneration/projectZephyr.mts
@@ -305,13 +305,14 @@ async function generateVSCodeConfig(
   // If console is USB, use the local snippet
   if (data.console === "USB") {
     westArgs.push("-S", "usb_serial_port");
-    westArgs.push("-DSNIPPET_ROOT=${workspaceFolder}");
+    westArgs.push("-D", "SNIPPET_ROOT=${workspaceFolder}");
   }
 
   westArgs.push(
-    "--",
-    `-DOPENOCD=\${command:${extensionName}.${GET_OPENOCD_ROOT}}/openocd`,
-    `-DOPENOCD_DEFAULT_PATH=\${command:${extensionName}.${GET_OPENOCD_ROOT}}/scripts`
+    "-D",
+    `OPENOCD=\${command:${extensionName}.${GET_OPENOCD_ROOT}}/openocd`,
+    "-D",
+    `OPENOCD_DEFAULT_PATH=\${command:${extensionName}.${GET_OPENOCD_ROOT}}/scripts`
   );
 
   const tasks = {
@@ -357,7 +358,11 @@ async function generateVSCodeConfig(
           kind: "build",
         },
         command: `"\${command:${extensionName}.${GET_WEST_PATH}}"`,
-        args: ["flash", "--build-dir", '"${workspaceFolder}/build"'],
+        args: [
+          "flash",
+          "--build-dir",
+          '"${workspaceFolder}/build"',
+        ],
         options: {
           cwd: `\${command:${extensionName}.${GET_ZEPHYR_WORKSPACE_PATH}}`,
         },

--- a/src/utils/pyenvUtil.mts
+++ b/src/utils/pyenvUtil.mts
@@ -34,10 +34,12 @@ export async function setupPyenv(): Promise<boolean> {
   return true;
 }
 
-export async function pyenvInstallPython(): Promise<string | undefined> {
+export async function pyenvInstallPython(
+  version: string = CURRENT_PYTHON_VERSION
+): Promise<string | undefined> {
   const targetDirectory = buildPyenvPath();
   const binDirectory = joinPosix(targetDirectory, "bin");
-  const command = `${binDirectory}/pyenv install -s ${CURRENT_PYTHON_VERSION}`;
+  const command = `${binDirectory}/pyenv install -s ${version}`;
 
   const customEnv = { ...process.env };
   customEnv["PYENV_ROOT"] = targetDirectory;
@@ -46,8 +48,8 @@ export async function pyenvInstallPython(): Promise<string | undefined> {
   }${customEnv[process.platform === "win32" ? "Path" : "PATH"]}`;
 
   const settingsTarget =
-    `${HOME_VAR}/.pico-sdk/python` + `/${CURRENT_PYTHON_VERSION}/python.exe`;
-  const pythonVersionPath = buildPython3Path(CURRENT_PYTHON_VERSION);
+    `${HOME_VAR}/.pico-sdk/python` + `/${version}/python.exe`;
+  const pythonVersionPath = buildPython3Path(version);
 
   if (existsSync(pythonVersionPath)) {
     return settingsTarget;
@@ -62,7 +64,7 @@ export async function pyenvInstallPython(): Promise<string | undefined> {
       const versionFolder = joinPosix(
         targetDirectory,
         "versions",
-        CURRENT_PYTHON_VERSION
+        version
       );
       const pyBin = joinPosix(versionFolder, "bin");
       mkdirSync(pythonVersionPath, { recursive: true });

--- a/src/utils/pyenvUtil.mts
+++ b/src/utils/pyenvUtil.mts
@@ -34,10 +34,12 @@ export async function setupPyenv(): Promise<boolean> {
   return true;
 }
 
-export async function pyenvInstallPython(): Promise<string | undefined> {
+export async function pyenvInstallPython(
+  version: string = CURRENT_PYTHON_VERSION
+): Promise<string | undefined> {
   const targetDirectory = buildPyenvPath();
   const binDirectory = joinPosix(targetDirectory, "bin");
-  const command = `${binDirectory}/pyenv install -s ${CURRENT_PYTHON_VERSION}`;
+  const command = `${binDirectory}/pyenv install -s ${version}`;
 
   const customEnv = { ...process.env };
   customEnv["PYENV_ROOT"] = targetDirectory;
@@ -46,8 +48,8 @@ export async function pyenvInstallPython(): Promise<string | undefined> {
   }${customEnv[process.platform === "win32" ? "Path" : "PATH"]}`;
 
   const settingsTarget =
-    `${HOME_VAR}/.pico-sdk/python` + `/${CURRENT_PYTHON_VERSION}/python.exe`;
-  const pythonVersionPath = buildPython3Path(CURRENT_PYTHON_VERSION);
+    `${HOME_VAR}/.pico-sdk/python` + `/${version}/python.exe`;
+  const pythonVersionPath = buildPython3Path(version);
 
   if (existsSync(pythonVersionPath)) {
     return settingsTarget;
@@ -64,7 +66,7 @@ export async function pyenvInstallPython(): Promise<string | undefined> {
       const versionFolder = joinPosix(
         targetDirectory,
         "versions",
-        CURRENT_PYTHON_VERSION
+        version
       );
       const pyBin = joinPosix(versionFolder, "bin");
       mkdirSync(pythonVersionPath, { recursive: true });

--- a/src/utils/pythonHelper.mts
+++ b/src/utils/pythonHelper.mts
@@ -29,10 +29,18 @@ function checkUnsupportedPython(pythonPath: string): boolean {
  * Python is loaded in the following order:
  * 1. The python path set in the User (per machine) settings.
  * 2. Check python extension for any python environments with version >= 3.9
- * 3. Download python if OS = macOS or Windows.
+ *    (or matching `version` exactly, if provided).
+ * 3. Download python if OS = macOS or Windows, pinned to `version` if provided.
+ * 4. On platforms with no downloader (e.g. Linux), if an exact `version` was
+ *    requested but not found, fall back to any valid Python and, if
+ *    `versionFallbackMessage` is provided, warn the user via that message.
  *
  * If a python environment is found, it will be set in the User (per machine) settings.
  *
+ * @param version Optional exact major.minor(.patch) version to require/prefer,
+ * e.g. "3.12.10". If omitted, any Python >= 3.9 is accepted.
+ * @param versionFallbackMessage Optional warning shown when falling back to a
+ * non-matching Python version on platforms without a downloader for `version`.
  * @returns If this function returns undefined, it means that the user will have to set
  * the python path manually in the User (per machine) settings. If the python executable
  * path is returned, it can be in Uri.fsPath format e.g. with backslashes on Windows.
@@ -304,7 +312,9 @@ async function findPythonInPythonExtension(
   if (
     resolved?.version &&
     checkPythonVersion(
-      resolved.version.major, resolved.version.minor, exactVersion
+      resolved.version.major,
+      resolved.version.minor,
+      exactVersion
     )
   ) {
     if (
@@ -330,7 +340,9 @@ async function findPythonInPythonExtension(
     if (
       resolved?.version &&
       checkPythonVersion(
-        resolved.version.major, resolved.version.minor, exactVersion
+        resolved.version.major,
+        resolved.version.minor,
+        exactVersion
       )
     ) {
       if (

--- a/src/utils/pythonHelper.mts
+++ b/src/utils/pythonHelper.mts
@@ -37,7 +37,20 @@ function checkUnsupportedPython(pythonPath: string): boolean {
  * the python path manually in the User (per machine) settings. If the python executable
  * path is returned, it can be in Uri.fsPath format e.g. with backslashes on Windows.
  */
-export default async function findPython(): Promise<string | undefined> {
+export default async function findPython(
+  version?: string,
+  versionFallbackMessage?: string
+): Promise<string | undefined> {
+  let exactVersion: { major: number; minor: number } | undefined;
+  if (version) {
+    const parts = version.split(".");
+    const major = parseInt(parts[0]);
+    const minor = parseInt(parts[1]);
+    if (!isNaN(major) && !isNaN(minor)) {
+      exactVersion = { major, minor };
+    }
+  }
+
   return window.withProgress(
     {
       location: ProgressLocation.Notification,
@@ -57,7 +70,7 @@ export default async function findPython(): Promise<string | undefined> {
         if (existsSync(pythonPath) && !checkUnsupportedPython(pythonPath)) {
           try {
             // TODO: only apply "" if path contains / or spaces
-            const version = execSync(
+            const versionOutput = execSync(
               `${
                 process.env.ComSpec === "powershell.exe" ? "&" : ""
               }"${pythonPath}" -V`,
@@ -70,14 +83,17 @@ export default async function findPython(): Promise<string | undefined> {
             )
               .trim()
               .split(" ");
-            if (version.length === 2 && checkPythonVersionRaw(version[1])) {
+            if (
+              versionOutput.length === 2 &&
+              checkPythonVersionRaw(versionOutput[1], exactVersion)
+            ) {
               return pythonPath;
             } else {
               Logger.warn(
                 LoggerSource.pythonHelper,
                 "Unable to check version of selected " +
                   "python path or it is not supported:",
-                version
+                versionOutput
               );
               // if version is not supported, clear the path
               await Settings.getInstance()?.updateGlobal(
@@ -108,7 +124,7 @@ export default async function findPython(): Promise<string | undefined> {
       }
 
       // Check python extension for any python environments with version >= 3.9
-      const awaitFind = findPythonInPythonExtension();
+      const awaitFind = findPythonInPythonExtension(exactVersion);
       // Timeout after 30s, as it can stall if there is no python available
       const onTimeout = new Promise<string>(resolve => {
         setTimeout(resolve, 30000, "timeout");
@@ -146,7 +162,7 @@ export default async function findPython(): Promise<string | undefined> {
             // TODO: add progress and maybe cancelable
             async () => {
               if (await setupPyenv()) {
-                pythonPath = (await pyenvInstallPython()) ?? undefined;
+                pythonPath = (await pyenvInstallPython(version)) ?? undefined;
                 if (pythonPath) {
                   await Settings.getInstance()?.updateGlobal(
                     SettingsKey.python3Path,
@@ -181,7 +197,8 @@ export default async function findPython(): Promise<string | undefined> {
                 const percent = prog.percent * 100;
                 progress.report({ increment: percent - progressState });
                 progressState = percent;
-              }
+              },
+              version
             );
             if (pythonPath) {
               await Settings.getInstance()?.updateGlobal(
@@ -195,6 +212,36 @@ export default async function findPython(): Promise<string | undefined> {
           break;
       }
 
+      // On platforms with no Python download (Linux/other), if an exact version
+      // was requested but not found, fall back to any valid Python and warn.
+      if (
+        exactVersion &&
+        versionFallbackMessage !== undefined &&
+        process.platform !== "darwin" &&
+        process.platform !== "win32"
+      ) {
+        const awaitFallback = findPythonInPythonExtension(undefined, true);
+        const onFallbackTimeout = new Promise<string>(resolve => {
+          setTimeout(resolve, 30000, "timeout");
+        });
+
+        await Promise.race([awaitFallback, onFallbackTimeout]).then(value => {
+          if (value !== "timeout") {
+            pythonPath = value;
+          }
+        });
+
+        if (pythonPath) {
+          void window.showWarningMessage(versionFallbackMessage);
+          await Settings.getInstance()?.updateGlobal(
+            SettingsKey.python3Path,
+            pythonPath
+          );
+
+          return pythonPath;
+        }
+      }
+
       return undefined;
     }
   );
@@ -206,7 +253,14 @@ function findPythonPathInUserSettings(): string | undefined {
   return settings?.getString(SettingsKey.python3Path);
 }
 
-function checkPythonVersion(mayor: number, minor: number): boolean {
+function checkPythonVersion(
+  mayor: number,
+  minor: number,
+  exactVersion?: { major: number; minor: number }
+): boolean {
+  if (exactVersion) {
+    return mayor === exactVersion.major && minor === exactVersion.minor;
+  }
   if (mayor < 3 || minor < 9) {
     return false;
   }
@@ -214,7 +268,10 @@ function checkPythonVersion(mayor: number, minor: number): boolean {
   return true;
 }
 
-function checkPythonVersionRaw(version: string): boolean {
+function checkPythonVersionRaw(
+  version: string,
+  exactVersion?: { major: number; minor: number }
+): boolean {
   const parts = version.split(".");
   const mayor = parseInt(parts[0]);
   const minor = parseInt(parts[1]);
@@ -229,19 +286,26 @@ function checkPythonVersionRaw(version: string): boolean {
     return false;
   }
 
-  return checkPythonVersion(mayor, minor);
+  return checkPythonVersion(mayor, minor, exactVersion);
 }
 
-async function findPythonInPythonExtension(): Promise<string | undefined> {
+async function findPythonInPythonExtension(
+  exactVersion?: { major: number; minor: number },
+  skipRefresh = false
+): Promise<string | undefined> {
   const pyApi = await PythonExtension.api();
-  await pyApi.environments.refreshEnvironments();
+  if (!skipRefresh) {
+    await pyApi.environments.refreshEnvironments();
+  }
   await pyApi.ready;
 
   const activeEnv = pyApi.environments.getActiveEnvironmentPath();
   const resolved = await pyApi.environments.resolveEnvironment(activeEnv);
   if (
     resolved?.version &&
-    checkPythonVersion(resolved.version.major, resolved.version.minor)
+    checkPythonVersion(
+      resolved.version.major, resolved.version.minor, exactVersion
+    )
   ) {
     if (
       resolved.executable.uri &&
@@ -265,7 +329,9 @@ async function findPythonInPythonExtension(): Promise<string | undefined> {
     const resolved = await pyApi.environments.resolveEnvironment(env.path);
     if (
       resolved?.version &&
-      checkPythonVersion(resolved.version.major, resolved.version.minor)
+      checkPythonVersion(
+        resolved.version.major, resolved.version.minor, exactVersion
+      )
     ) {
       if (
         resolved.executable.uri &&
@@ -293,16 +359,15 @@ async function findPythonInPythonExtension(): Promise<string | undefined> {
   return undefined;
 }
 
-export function showPythonNotFoundError(): void {
+export function showPythonNotFoundError(
+  message =
+    "Failed to find any valid Python installation. " +
+    "Make sure Python >=3.9 is installed. " +
+    "You can set a Python executable directly in your " +
+    "user settings or select in the Python extension."
+): void {
   void window
-    .showErrorMessage(
-      "Failed to find any valid Python installation. " +
-        "Make sure Python >=3.9 is installed. " +
-        "You can set a Python executable directly in your " +
-        "user settings or select in the Python extension.",
-      "Open Python Extension",
-      "Edit Settings"
-    )
+    .showErrorMessage(message, "Open Python Extension", "Edit Settings")
     .then(selected => {
       if (selected === "Open Python Extension") {
         void commands.executeCommand("python.setInterpreter");
@@ -313,6 +378,16 @@ export function showPythonNotFoundError(): void {
         );
       }
     });
+}
+
+export function showZephyrPythonNotFoundError(): void {
+  showPythonNotFoundError(
+    "Failed to find a Python 3.12 installation. " +
+      "Zephyr requires exactly Python 3.12 — " +
+      "other versions are not supported. " +
+      "You can set a Python executable directly in your " +
+      "user settings or select in the Python extension."
+  );
 }
 
 export function getSystemPythonVersion(): string | undefined {

--- a/src/utils/setupZephyr.mts
+++ b/src/utils/setupZephyr.mts
@@ -20,7 +20,7 @@ import {
   downloadFileGot,
 } from "./download.mjs";
 import Settings, { HOME_VAR, SettingsKey } from "../settings.mjs";
-import findPython, { showPythonNotFoundError } from "./pythonHelper.mjs";
+import findPython, { showZephyrPythonNotFoundError } from "./pythonHelper.mjs";
 import { checkGitWithProgress } from "./gitUtil.mjs";
 import VersionBundlesLoader, { type VersionBundle } from "./versionBundles.mjs";
 import {
@@ -33,6 +33,7 @@ import {
   WINDOWS_X86_7ZIP_DOWNLOAD_URL,
   WINDOWS_X86_DTC_DOWNLOAD_URL,
   WINDOWS_X86_GPERF_DOWNLOAD_URL,
+  ZEPHYR_PYTHON_VERSION,
 } from "./sharedConstants.mjs";
 import { vsExists } from "./vsHelpers.mjs";
 import which from "which";
@@ -988,7 +989,12 @@ export async function setupZephyr(
       }
 
       // install python (if necessary)
-      const python3Path = (await findPython())?.replace(
+      const python3Path = (await findPython(
+        ZEPHYR_PYTHON_VERSION,
+        "Python 3.12 is strongly recommended for Zephyr. " +
+          "Other versions may fail to install required packages. " +
+          "Consider installing Python 3.12 for full compatibility."
+      ))?.replace(
         HOME_VAR,
         homedir().replaceAll("\\", "/")
       );
@@ -1001,7 +1007,7 @@ export async function setupZephyr(
           LoggerSource.zephyrSetup,
           "Failed to find Python3 executable."
         );
-        showPythonNotFoundError();
+        showZephyrPythonNotFoundError();
 
         return false;
       }

--- a/src/utils/setupZephyr.mts
+++ b/src/utils/setupZephyr.mts
@@ -1332,6 +1332,28 @@ export async function setupZephyr(
         return false;
       }
 
+      // Before zephyr-export, matching the order in Zephyr's getting-started:
+      // the export command imports build_helpers, which has imported jsonschema
+      // since zephyrproject-rtos/zephyr@0f07a53.
+      installedSuccessfully = await installWestPyDeps(
+        westExe,
+        zephyrWorkspaceDirectory,
+        customEnv
+      );
+      if (!installedSuccessfully) {
+        progress.report({
+          message: "Failed",
+          increment: 100,
+        });
+        void window.showErrorMessage(
+          "Failed to install West Python dependencies. " +
+            "Cannot continue Zephyr setup. " +
+            "See extension host output for more details."
+        );
+
+        return false;
+      }
+
       const zephyrExportCommand: string = `"${westExe}" zephyr-export`;
       Logger.info(LoggerSource.zephyrSetup, "Exporting Zephyr CMake Files...");
 
@@ -1351,25 +1373,6 @@ export async function setupZephyr(
           increment: 100,
         });
         void window.showErrorMessage("Error exporting Zephyr CMake files.");
-
-        return false;
-      }
-
-      installedSuccessfully = await installWestPyDeps(
-        westExe,
-        zephyrWorkspaceDirectory,
-        customEnv
-      );
-      if (!installedSuccessfully) {
-        progress.report({
-          message: "Failed",
-          increment: 100,
-        });
-        void window.showErrorMessage(
-          "Failed to install West Python dependencies. " +
-            "Cannot continue Zephyr setup. " +
-            "See extension host output for more details."
-        );
 
         return false;
       }

--- a/src/utils/sharedConstants.mts
+++ b/src/utils/sharedConstants.mts
@@ -1,8 +1,5 @@
-export const WINDOWS_X86_PYTHON_DOWNLOAD_URL =
-  "https://www.python.org/ftp/python/3.13.7/python-3.13.7-embed-amd64.zip";
-export const WINDOWS_ARM64_PYTHON_DOWNLOAD_URL =
-  "https://www.python.org/ftp/python/3.13.7/python-3.13.7-embed-arm64.zip";
 export const CURRENT_PYTHON_VERSION = "3.13.7";
+export const ZEPHYR_PYTHON_VERSION = "3.12.10";
 export const GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py";
 
 export const CURRENT_DATA_VERSION = "0.18.0";

--- a/src/utils/sharedConstants.mts
+++ b/src/utils/sharedConstants.mts
@@ -1,8 +1,5 @@
-export const WINDOWS_X86_PYTHON_DOWNLOAD_URL =
-  "https://www.python.org/ftp/python/3.13.7/python-3.13.7-embed-amd64.zip";
-export const WINDOWS_ARM64_PYTHON_DOWNLOAD_URL =
-  "https://www.python.org/ftp/python/3.13.7/python-3.13.7-embed-arm64.zip";
 export const CURRENT_PYTHON_VERSION = "3.13.7";
+export const ZEPHYR_PYTHON_VERSION = "3.12.10";
 export const GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py";
 
 export const CURRENT_DATA_VERSION = "0.22.0";


### PR DESCRIPTION
Use Python 3.12 with Zephyr, as later versions aren't supported - fixes #267

Fix link to docs - fixes #268

Add instructions to allow script execution for virtual environment - fixes #269

Fix argument passing to west build - fixes #270